### PR TITLE
hotfix incorrect actionspace descent_env

### DIFF
--- a/bluesky_gym/envs/descent_env.py
+++ b/bluesky_gym/envs/descent_env.py
@@ -59,7 +59,7 @@ class DescentEnv(gym.Env):
             }
         )
        
-        self.action_space = spaces.Box(-1, 1, shape=(2,), dtype=np.float64)
+        self.action_space = spaces.Box(-1, 1, shape=(1,), dtype=np.float64)
 
         assert render_mode is None or render_mode in self.metadata["render_modes"]
         self.render_mode = render_mode


### PR DESCRIPTION
For some reason the action space was changed to size (2,) in commit cd36117. This PR fixes this by reverting it back to the correct shape of (1,)
