### PR TITLE
update dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,12 @@
 name = "bluesky-gym"
 version = "0.1.0"
 dependencies = [
-    "bluesky-simulator",
-    "torch==2.2.0",
-    "pygame==2.5.2",
-    "gymnasium",
-    "stable-baselines3==2.2.1",
-    "numpy==1.24",
-    "bluesky-simulator",
+    "torch==2.6.0",
+    "pygame==2.6.1",
+    "gymnasium==1.1.1",
+    "stable-baselines3==2.6.0",
+    "numpy==2.2.4",
+    "bluesky-simulator==1.0.3",
 ]
 
 authors = [


### PR DESCRIPTION
Currently building from the pyproject.toml file (and pip install) fails. This is because of conflicting dependencies within the project because not every dependency has a specified version (and hence downloads the latest).

Updating the dependencies to:

dependencies = [
    "torch==2.6.0",
    "pygame==2.6.1",
    "gymnasium==1.1.1",
    "stable-baselines3==2.6.0",
    "numpy==2.2.4",
    "bluesky-simulator==1.0.3",
]

fixes the problem. 
