### PR TITLE
fixed bug that causes BlueSky to be initialised twice

### DIFF
--- a/bluesky_gym/envs/descent_env.py
+++ b/bluesky_gym/envs/descent_env.py
@@ -65,7 +65,8 @@ class DescentEnv(gym.Env):
         self.render_mode = render_mode
 
         # initialize bluesky as non-networked simulation node
-        bs.init(mode='sim', detached=True)
+        if bs.sim is None:
+            bs.init(mode='sim', detached=True)
 
         # initialize dummy screen and set correct sim speed
         bs.scr = ScreenDummy()
@@ -275,4 +276,4 @@ class DescentEnv(gym.Env):
         self.clock.tick(self.metadata["render_fps"])
         
     def close(self):
-        pass
+        bs.stack.stack('quit')

--- a/bluesky_gym/envs/horizontal_cr_env.py
+++ b/bluesky_gym/envs/horizontal_cr_env.py
@@ -65,7 +65,8 @@ class HorizontalCREnv(gym.Env):
         self.render_mode = render_mode
 
         # initialize bluesky as non-networked simulation node
-        bs.init(mode='sim', detached=True)
+        if bs.sim is None:
+            bs.init(mode='sim', detached=True)
 
         # initialize dummy screen and set correct sim speed
         bs.scr = ScreenDummy()
@@ -395,4 +396,4 @@ class HorizontalCREnv(gym.Env):
         self.clock.tick(self.metadata["render_fps"])
         
     def close(self):
-        pass
+        bs.stack.stack('quit')

--- a/bluesky_gym/envs/merge_env.py
+++ b/bluesky_gym/envs/merge_env.py
@@ -79,7 +79,8 @@ class MergeEnv(gym.Env):
         self.render_mode = render_mode
 
         # initialize bluesky as non-networked simulation node
-        bs.init(mode='sim', detached=True)
+        if bs.sim is None:
+            bs.init(mode='sim', detached=True)
 
         # initialize dummy screen and set correct sim speed
         bs.scr = ScreenDummy()
@@ -451,4 +452,4 @@ class MergeEnv(gym.Env):
         self.clock.tick(self.metadata["render_fps"])
         
     def close(self):
-        pass
+        bs.stack.stack('quit')

--- a/bluesky_gym/envs/plan_waypoint_env.py
+++ b/bluesky_gym/envs/plan_waypoint_env.py
@@ -62,7 +62,8 @@ class PlanWaypointEnv(gym.Env):
         self.render_mode = render_mode
 
         # initialize bluesky as non-networked simulation node
-        bs.init(mode='sim', detached=True)
+        if bs.sim is None:
+            bs.init(mode='sim', detached=True)
 
         # initialize dummy screen and set correct sim speed
         bs.scr = ScreenDummy()
@@ -297,4 +298,4 @@ class PlanWaypointEnv(gym.Env):
         self.clock.tick(self.metadata["render_fps"])
         
     def close(self):
-        pass
+        bs.stack.stack('quit')

--- a/bluesky_gym/envs/sector_cr_env.py
+++ b/bluesky_gym/envs/sector_cr_env.py
@@ -70,7 +70,8 @@ class SectorCREnv(gym.Env):
         self.render_mode = render_mode
 
         # initialize bluesky as non-networked simulation node
-        bs.init(mode='sim', detached=True)
+        if bs.sim is None:
+            bs.init(mode='sim', detached=True)
 
         # initialize dummy screen and set correct sim speed
         bs.scr = ScreenDummy()
@@ -442,4 +443,4 @@ class SectorCREnv(gym.Env):
         self.clock.tick(self.metadata["render_fps"])
     
     def close(self):
-        pass
+        bs.stack.stack('quit')

--- a/bluesky_gym/envs/static_obstacle_env.py
+++ b/bluesky_gym/envs/static_obstacle_env.py
@@ -76,7 +76,8 @@ class StaticObstacleEnv(gym.Env):
         self.render_mode = render_mode
 
         # initialize bluesky as non-networked simulation node
-        bs.init(mode='sim', detached=True)
+        if bs.sim is None:
+            bs.init(mode='sim', detached=True)
 
         # initialize dummy screen and set correct sim speed
         bs.scr = ScreenDummy()
@@ -442,4 +443,4 @@ class StaticObstacleEnv(gym.Env):
         self.clock.tick(self.metadata["render_fps"])
 
     def close(self):
-        pass
+        bs.stack.stack('quit')

--- a/bluesky_gym/envs/vertical_cr_env.py
+++ b/bluesky_gym/envs/vertical_cr_env.py
@@ -88,7 +88,8 @@ class VerticalCREnv(gym.Env):
         self.render_mode = render_mode
 
         # initialize bluesky as non-networked simulation node
-        bs.init(mode='sim', detached=True)
+        if bs.sim is None:
+            bs.init(mode='sim', detached=True)
 
         # initialize dummy screen and set correct sim speed
         bs.scr = ScreenDummy()
@@ -426,4 +427,4 @@ class VerticalCREnv(gym.Env):
         self.clock.tick(self.metadata["render_fps"])
         
     def close(self):
-        pass
+        bs.stack.stack('quit')


### PR DESCRIPTION
Pull request addressing Issue #36. This solves both the `Attempt to reimplement` warnings and the `AttributeError` caused by BlueSky being initialised twice.

Changes:
- In all environments, a check is added in the `__init__` to make sure BlueSky is not already initialised before issuing the initialisation.
```
if bs.sim is None:
   bs.init(mode='sim', detached=True)
```
- In the method env.close(), the currently active simulation node is quit. 