### PR TITLE
Refactor random number generation to use self.np_random for seeding environments correctly

### DIFF
--- a/bluesky_gym/envs/common/functions.py
+++ b/bluesky_gym/envs/common/functions.py
@@ -41,7 +41,7 @@ def get_point_at_distance(lat1, lon1, d, bearing, R=6371):
     )
     return np.degrees(lat2), np.degrees(lon2)
 
-def random_point_on_circle(radius: float) -> np.array:
+def random_point_on_circle(radius: float,generator) -> np.array:
     """ Get a random point on a circle circumference with given radius
     Parameters
     __________
@@ -53,7 +53,7 @@ def random_point_on_circle(radius: float) -> np.array:
     point: np.array
         randomly sampled point
     """
-    alpha = 2 * np.pi * np.random.uniform(0., 1.)
+    alpha = 2 * np.pi * generator.uniform(0., 1.)
     x = radius * np.cos(alpha)
     y = radius * np.sin(alpha)
     return np.array([x, y])

--- a/bluesky_gym/envs/common/functions.py
+++ b/bluesky_gym/envs/common/functions.py
@@ -1,5 +1,7 @@
 import numpy as np
 from typing import List
+import numpy as np
+
 
 def bound_angle_positive_negative_180(angle_deg: float) -> float:
     """ maps any angle in degrees to the [-180,180] interval 
@@ -41,7 +43,7 @@ def get_point_at_distance(lat1, lon1, d, bearing, R=6371):
     )
     return np.degrees(lat2), np.degrees(lon2)
 
-def random_point_on_circle(radius: float,generator) -> np.array:
+def random_point_on_circle(radius: float,generator: np.random.Generator) -> np.array:
     """ Get a random point on a circle circumference with given radius
     Parameters
     __________

--- a/bluesky_gym/envs/common/polygon_generator.py
+++ b/bluesky_gym/envs/common/polygon_generator.py
@@ -3,10 +3,11 @@ from typing import List, Tuple
 from PIL import Image, ImageDraw
 import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
 def generate_polygon(center: Tuple[float, float], avg_radius: float,
                      irregularity: float, spikiness: float,
-                     num_vertices: int) -> List[Tuple[float, float]]:
+                     num_vertices: int, generator: np.random.Generator) -> List[Tuple[float, float]]:
     """
     Start with the center of the polygon at center, then creates the
     polygon by sampling points on a circle around the center.
@@ -30,6 +31,8 @@ def generate_polygon(center: Tuple[float, float], avg_radius: float,
             the circumference.
         num_vertices (int):
             the number of vertices of the polygon.
+        generator:
+            numpy random generator instance.
     Returns:
         List[Tuple[float, float]]: list of vertices, in CCW order.
     """
@@ -41,13 +44,13 @@ def generate_polygon(center: Tuple[float, float], avg_radius: float,
 
     irregularity *= 2 * math.pi / num_vertices
     spikiness *= avg_radius
-    angle_steps = random_angle_steps(num_vertices, irregularity)
+    angle_steps = random_angle_steps(num_vertices, irregularity, generator)
 
     # now generate the points
     points = []
-    angle = random.uniform(0, 2 * math.pi)
+    angle = generator.uniform(0, 2 * math.pi)
     for i in range(num_vertices):
-        radius = clip(random.gauss(avg_radius, spikiness), 0, 2 * avg_radius)
+        radius = clip(generator.normal(avg_radius, spikiness), 0, 2 * avg_radius)
         point = (center[0] + radius * math.cos(angle),
                  center[1] + radius * math.sin(angle))
         points.append(point)
@@ -55,7 +58,7 @@ def generate_polygon(center: Tuple[float, float], avg_radius: float,
 
     return points
 
-def random_angle_steps(steps: int, irregularity: float) -> List[float]:
+def random_angle_steps(steps: int, irregularity: float, generator: np.random.Generator) -> List[float]:
     """Generates the division of a circumference in random angles.
 
     Args:
@@ -63,6 +66,8 @@ def random_angle_steps(steps: int, irregularity: float) -> List[float]:
             the number of angles to generate.
         irregularity (float):
             variance of the spacing of the angles between consecutive vertices.
+        generator:
+            numpy random generator instance.
     Returns:
         List[float]: the list of the random angles.
     """
@@ -72,7 +77,7 @@ def random_angle_steps(steps: int, irregularity: float) -> List[float]:
     upper = (2 * math.pi / steps) + irregularity
     cumsum = 0
     for i in range(steps):
-        angle = random.uniform(lower, upper)
+        angle = generator.uniform(lower, upper)
         angles.append(angle)
         cumsum += angle
 
@@ -89,38 +94,45 @@ def clip(value, lower, upper):
     """
     return min(upper, max(value, lower))
 
-vertices = generate_polygon(center=(250, 250),
-                            avg_radius=100,
-                            irregularity=0.35,
-                            spikiness=0.2,
-                            num_vertices=16)
+
+#making it safe
+if __name__ == "__main__":
+
+    # Example usage fix
+    rng = np.random.default_rng()
+    vertices = generate_polygon(center=(250, 250),
+                                avg_radius=100,
+                                irregularity=0.35,
+                                spikiness=0.2,
+                                num_vertices=16,
+                                generator=rng)
 
 
-black = (0, 0, 0)
-white = (255, 255, 255)
-img = Image.new('RGB', (500, 500), white)
-im_px_access = img.load()
-draw = ImageDraw.Draw(img)
+    black = (0, 0, 0)
+    white = (255, 255, 255)
+    img = Image.new('RGB', (500, 500), white)
+    im_px_access = img.load()
+    draw = ImageDraw.Draw(img)
 
-# either use .polygon(), if you want to fill the area with a solid colour
-draw.polygon(vertices, outline=black, fill=black)
+    # either use .polygon(), if you want to fill the area with a solid colour
+    draw.polygon(vertices, outline=black, fill=black)
 
-# or .line() if you want to control the line thickness, or use both methods together!
-draw.line(vertices + [vertices[0]], width=2, fill=black)
-img.show()
+    # or .line() if you want to control the line thickness, or use both methods together!
+    draw.line(vertices + [vertices[0]], width=2, fill=black)
+    img.show()
 
-sector_array = np.asarray(img)
+    sector_array = np.asarray(img)
 
-sector_bitmap = np.zeros((np.size(sector_array, 0), np.size(sector_array, 1)))
+    sector_bitmap = np.zeros((np.size(sector_array, 0), np.size(sector_array, 1)))
 
 
-for row in range(np.size(sector_array, 0)):
-    for column in range(np.size(sector_array, 1)):
-        if np.array_equal(sector_array[row, column, :], np.array([255, 255, 255])):
-            sector_bitmap[row, column] = 0
-        else:
-            sector_bitmap[row, column] = 1
+    for row in range(np.size(sector_array, 0)):
+        for column in range(np.size(sector_array, 1)):
+            if np.array_equal(sector_array[row, column, :], np.array([255, 255, 255])):
+                sector_bitmap[row, column] = 0
+            else:
+                sector_bitmap[row, column] = 1
 
-# plt.plot(sector_bitmap)
-# plt.show()
-plt.imshow(sector_bitmap,cmap='gray_r')
+    # plt.plot(sector_bitmap)
+    # plt.show()
+    plt.imshow(sector_bitmap,cmap='gray_r')

--- a/bluesky_gym/envs/descent_env.py
+++ b/bluesky_gym/envs/descent_env.py
@@ -168,8 +168,8 @@ class DescentEnv(gym.Env):
         self.total_reward = 0
         self.final_altitude = 0
 
-        alt_init = np.random.randint(ALT_MIN, ALT_MAX)
-        self.target_alt = alt_init + np.random.randint(-TARGET_ALT_DIF,TARGET_ALT_DIF)
+        alt_init = self.np_random.integers(ALT_MIN, ALT_MAX)
+        self.target_alt = alt_init + self.np_random.integers(-TARGET_ALT_DIF,TARGET_ALT_DIF)
 
         bs.traf.cre('KL001',actype="A320",acalt=alt_init,acspd=AC_SPD)
         bs.traf.swvnav[0] = False

--- a/bluesky_gym/envs/horizontal_cr_env.py
+++ b/bluesky_gym/envs/horizontal_cr_env.py
@@ -128,9 +128,9 @@ class HorizontalCREnv(gym.Env):
     def _generate_conflicts(self, acid = 'KL001'):
         target_idx = bs.traf.id2idx(acid)
         for i in range(NUM_INTRUDERS):
-            dpsi = np.random.randint(45,315)
-            cpa = np.random.randint(0,INTRUSION_DISTANCE)
-            tlosh = np.random.randint(100,1000)
+            dpsi = self.np_random.integers(45,315)
+            cpa = self.np_random.integers(0,INTRUSION_DISTANCE)
+            tlosh = self.np_random.integers(100,1000)
             bs.traf.creconfs(acid=f'{i}',actype="A320",targetidx=target_idx,dpsi=dpsi,dcpa=cpa,tlosh=tlosh)
 
     def _generate_waypoint(self, acid = 'KL001'):
@@ -138,7 +138,7 @@ class HorizontalCREnv(gym.Env):
         self.wpt_lon = []
         self.wpt_reach = []
         for i in range(NUM_WAYPOINTS):
-            wpt_dis_init = np.random.randint(WAYPOINT_DISTANCE_MIN, WAYPOINT_DISTANCE_MAX)
+            wpt_dis_init = self.np_random.integers(WAYPOINT_DISTANCE_MIN, WAYPOINT_DISTANCE_MAX)
             wpt_hdg_init = 0
 
             ac_idx = bs.traf.id2idx(acid)

--- a/bluesky_gym/envs/merge_env.py
+++ b/bluesky_gym/envs/merge_env.py
@@ -113,8 +113,8 @@ class MergeEnv(gym.Env):
         self.faf_reached = 0
 
         # ownship spawn location
-        bearing_to_pos = random.uniform(-D_HEADING, D_HEADING) # heading radial towards FAF
-        distance_to_pos = random.uniform(SPAWN_DISTANCE_MIN,SPAWN_DISTANCE_MAX)  # distance to faf 
+        bearing_to_pos = self.np_random.uniform(-D_HEADING, D_HEADING) # heading radial towards FAF
+        distance_to_pos = self.np_random.uniform(SPAWN_DISTANCE_MIN,SPAWN_DISTANCE_MAX)  # distance to faf 
         rlat, rlon = fn.get_point_at_distance(FIX_LAT, FIX_LON, distance_to_pos, bearing_to_pos)
 
         bs.traf.cre('KL001',actype="A320",acspd=AC_SPD, aclat= rlat, aclon= rlon, achdg=bearing_to_pos-180,acalt=10000)
@@ -148,8 +148,8 @@ class MergeEnv(gym.Env):
     
     def _gen_aircraft(self):
         for i in range(NUM_AC-1):
-            bearing_to_pos = random.uniform(-D_HEADING, D_HEADING) # heading radial towards FAF
-            distance_to_pos = random.uniform(INTRUDER_DISTANCE_MIN,INTRUDER_DISTANCE_MAX) # distance to faf 
+            bearing_to_pos = self.np_random.uniform(-D_HEADING, D_HEADING) # heading radial towards FAF
+            distance_to_pos = self.np_random.uniform(INTRUDER_DISTANCE_MIN,INTRUDER_DISTANCE_MAX) # distance to faf 
             lat_ac, lon_ac = fn.get_point_at_distance(self.wpt_lat, self.wpt_lon, distance_to_pos, bearing_to_pos)
 
             bs.traf.cre(f'INT{i}',actype="A320",acspd=AC_SPD,aclat=lat_ac,aclon=lon_ac,achdg=bearing_to_pos-180,acalt=10000)

--- a/bluesky_gym/envs/plan_waypoint_env.py
+++ b/bluesky_gym/envs/plan_waypoint_env.py
@@ -149,7 +149,7 @@ class PlanWaypointEnv(gym.Env):
     def _get_action(self,action):
 
         # Transform action to the change in heading
-        # action = np.random.randint(-100,100)/100
+        # action = self.np_random.integers(-100,100)/100
         action = self.ac_hdg + action * D_HEADING
 
         bs.stack.stack(f"HDG KL001 {action[0]}")
@@ -203,8 +203,8 @@ class PlanWaypointEnv(gym.Env):
         self.wpt_lon = []
         self.wpt_reach = []
         for i in range(NUM_WAYPOINTS):
-            wpt_dis_init = np.random.randint(WAYPOINT_DISTANCE_MIN, WAYPOINT_DISTANCE_MAX)
-            wpt_hdg_init = np.random.randint(0, 359)
+            wpt_dis_init = self.np_random.integers(WAYPOINT_DISTANCE_MIN, WAYPOINT_DISTANCE_MAX)
+            wpt_hdg_init = self.np_random.integers(0, 359)
 
             ac_idx = bs.traf.id2idx(acid)
 

--- a/bluesky_gym/envs/sector_cr_env.py
+++ b/bluesky_gym/envs/sector_cr_env.py
@@ -97,10 +97,10 @@ class SectorCREnv(gym.Env):
         self._generate_polygon() # Create airspace polygon
         
         if self.density_mode == "normal":
-            rand_density = np.random.normal(AC_DENSITY_MU, AC_DENSITY_SIGMA)
+            rand_density = self.np_random.normal(AC_DENSITY_MU, AC_DENSITY_SIGMA)
             self.num_ac = int(max(np.ceil(rand_density * self.poly_area), NUM_AC_STATE+1)) # Get total number of AC in the airspace including agent (min = 3)
         else:
-            rand_density = np.random.uniform(*AC_DENSITY_RANGE)
+            rand_density = self.np_random.uniform(*AC_DENSITY_RANGE)
             self.num_ac = int(max(np.ceil(rand_density * self.poly_area), NUM_AC_STATE+1)) # Get total number of AC in the airspace including agent (min = 3)
         
         self._generate_waypoints() # Create waypoints for aircraft
@@ -142,12 +142,12 @@ class SectorCREnv(gym.Env):
     def _generate_polygon(self):
         
         R = np.sqrt(POLY_AREA_RANGE[1] / np.pi)
-        p = [fn.random_point_on_circle(R) for _ in range(3)] # 3 random points to start building the polygon
+        p = [fn.random_point_on_circle(R,self.np_random) for _ in range(3)] # 3 random points to start building the polygon
         p = fn.sort_points_clockwise(p)
         p_area = fn.polygon_area(p)
         
         while p_area < POLY_AREA_RANGE[0]:
-            p.append(fn.random_point_on_circle(R))
+            p.append(fn.random_point_on_circle(R,self.np_random))
             p = fn.sort_points_clockwise(p)
             p_area = fn.polygon_area(p)
         
@@ -172,7 +172,7 @@ class SectorCREnv(gym.Env):
             edges.append((p1, p2, len_edge))
             perim_tot += len_edge
         
-        d_list = [np.random.uniform(0, perim_tot) for _ in range(self.num_ac)] # Each ac including agent is given a waypoint
+        d_list = [self.np_random.uniform(0, perim_tot) for _ in range(self.num_ac)] # Each ac including agent is given a waypoint
         d_list.sort()
         
         self.wpts = [] # In terms of NM
@@ -199,7 +199,7 @@ class SectorCREnv(gym.Env):
         init_p_latlong = []
         
         while len(init_p_latlong) < self.num_ac:
-            p = np.array([np.random.uniform(min_x, max_x), np.random.uniform(min_y, max_y)])
+            p = np.array([self.np_random.uniform(min_x, max_x), self.np_random.uniform(min_y, max_y)])
             p = fn.nm_to_latlong(CENTER, p)
             if bs.tools.areafilter.checkInside(self.poly_name, np.array([p[0]]), np.array([p[1]]), np.array([ALTITUDE*FL2M])):
                 init_p_latlong.append(p)

--- a/bluesky_gym/envs/static_obstacle_env.py
+++ b/bluesky_gym/envs/static_obstacle_env.py
@@ -152,14 +152,14 @@ class StaticObstacleEnv(gym.Env):
         return observation, reward, done, terminated, info
 
     def _generate_polygon(self, centre):
-        poly_area = np.random.randint(OBSTACLE_AREA_RANGE[0]*2, OBSTACLE_AREA_RANGE[1])
+        poly_area = self.np_random.integers(OBSTACLE_AREA_RANGE[0]*2, OBSTACLE_AREA_RANGE[1])
         R = np.sqrt(poly_area/ np.pi)
-        p = [fn.random_point_on_circle(R) for _ in range(3)] # 3 random points to start building the polygon
+        p = [fn.random_point_on_circle(R,self.np_random) for _ in range(3)] # 3 random points to start building the polygon
         p = fn.sort_points_clockwise(p)
         p_area = fn.polygon_area(p)
         
         while p_area < OBSTACLE_AREA_RANGE[0]:
-            p.append(fn.random_point_on_circle(R))
+            p.append(fn.random_point_on_circle(R,self.np_random))
             p = fn.sort_points_clockwise(p)
             p_area = fn.polygon_area(p)
         
@@ -204,8 +204,8 @@ class StaticObstacleEnv(gym.Env):
         loop_counter = 0
         while check_inside_var:
             loop_counter += 1
-            wpt_dis_init = np.random.randint(WAYPOINT_DISTANCE_MIN, WAYPOINT_DISTANCE_MAX)
-            wpt_hdg_init = np.random.randint(0, 360)
+            wpt_dis_init = self.np_random.integers(WAYPOINT_DISTANCE_MIN, WAYPOINT_DISTANCE_MAX)
+            wpt_hdg_init = self.np_random.integers(0, 360)
             wpt_lat, wpt_lon = fn.get_point_at_distance(bs.traf.lat[ac_idx], bs.traf.lon[ac_idx], wpt_dis_init, wpt_hdg_init)
 
             inside_temp = []
@@ -225,8 +225,8 @@ class StaticObstacleEnv(gym.Env):
         self.obstacle_centre_lon = []
         
         for i in range(num_obstacles):
-            obstacle_dis_from_reference = np.random.randint(OBSTACLE_DISTANCE_MIN, OBSTACLE_DISTANCE_MAX)
-            obstacle_hdg_from_reference = np.random.randint(0, 360)
+            obstacle_dis_from_reference = self.np_random.integers(OBSTACLE_DISTANCE_MIN, OBSTACLE_DISTANCE_MAX)
+            obstacle_hdg_from_reference = self.np_random.integers(0, 360)
             ac_idx = bs.traf.id2idx(acid)
 
             obstacle_centre_lat, obstacle_centre_lon = fn.get_point_at_distance(bs.traf.lat[ac_idx], bs.traf.lon[ac_idx], obstacle_dis_from_reference, obstacle_hdg_from_reference)    

--- a/bluesky_gym/envs/vertical_cr_env.py
+++ b/bluesky_gym/envs/vertical_cr_env.py
@@ -186,14 +186,14 @@ class VerticalCREnv(gym.Env):
         altitude = bs.traf.alt[target_idx]
         spd = bs.traf.gs[target_idx]
         for i in range(NUM_INTRUDERS):
-            dpsi = np.random.randint(45,315)
-            cpa = np.random.randint(0,INTRUSION_DISTANCE)
-            tlosh = np.random.randint(100,int((DEFAULT_RWY_DIS*0.9)*1000/spd))
+            dpsi = self.np_random.integers(45,315)
+            cpa = self.np_random.integers(0,INTRUSION_DISTANCE)
+            tlosh = self.np_random.integers(100,int((DEFAULT_RWY_DIS*0.9)*1000/spd))
             average_tod = (DEFAULT_RWY_DIS*1000/spd) - 2*self.target_alt/ACTION_2_MS
             if tlosh > average_tod:
-                dH = np.random.randint(int(-altitude + 500),int((self.target_alt - altitude) + 100))
+                dH = self.np_random.integers(int(-altitude + 500),int((self.target_alt - altitude) + 100))
             else:
-                dH = np.random.randint(int((self.target_alt - altitude) - 500),int((self.target_alt - altitude) + 500))
+                dH = self.np_random.integers(int((self.target_alt - altitude) - 500),int((self.target_alt - altitude) + 500))
             tlosv = 100000000000.
 
             bs.traf.creconfs(acid=f'{i}',actype="A320",targetidx=target_idx,dpsi=dpsi,dcpa=cpa,tlosh=tlosh,dH=dH,tlosv=tlosv)
@@ -265,8 +265,8 @@ class VerticalCREnv(gym.Env):
         self.total_intrusions = 0
         self.final_altitude = 0
 
-        alt_init = np.random.randint(ALT_MIN, ALT_MAX)
-        self.target_alt = alt_init + np.random.randint(-TARGET_ALT_DIF,TARGET_ALT_DIF)
+        alt_init = self.np_random.integers(ALT_MIN, ALT_MAX)
+        self.target_alt = alt_init + self.np_random.integers(-TARGET_ALT_DIF,TARGET_ALT_DIF)
 
         bs.traf.cre('KL001',actype="A320",acalt=alt_init,acspd=AC_SPD)
         bs.traf.swvnav[0] = False


### PR DESCRIPTION
# Implement Deterministic Seeding via self.np_random

## Description
This PR standardizes the random number generation across all environments to ensure full reproducibility. All instances of randomness (including internal function calls) have been updated to use the Gymnasium standard `self.np_random` generator.

This allows users to seed the environment initialization and the resulting episode sequence using `env.reset(seed=...)`.

## Key Changes
*   **Replaced Global Randomness**: Refactored all environments to use `self.np_random` instead of `numpy.random` or standard `random` library calls.
*   **Propagated RNG**: Updated helper functions to accept the environment's random number generator instance to ensure consistent seeding throughout the complete stack.
*   **Deterministic Behavior**: 
    *   Calling `env.reset(seed=X)` once after env creation, guarantees that the specific episode and the subsequent sequence of episodes are deterministic initizialized.
    *   Calling `env.reset()` (without a seed) maintains standard stochastic behavior for diverse training data.

