### PR TITLE
Deprecated obsolete ScreenDummy

### DIFF
--- a/bluesky_gym/envs/common/screen_dummy.py
+++ b/bluesky_gym/envs/common/screen_dummy.py
@@ -1,3 +1,4 @@
+''' This module is deprecated and will be removed in a later version of BlueSky-gym. '''
 from warnings import deprecated
 from bluesky.simulation import ScreenIO
 

--- a/bluesky_gym/envs/common/screen_dummy.py
+++ b/bluesky_gym/envs/common/screen_dummy.py
@@ -1,5 +1,8 @@
+from warnings import deprecated
 from bluesky.simulation import ScreenIO
 
+
+@deprecated('Subclassing ScreenIO in detached simulations is no longer necessary for BlueSky>=1.0.0')
 class ScreenDummy(ScreenIO):
     """
     Dummy class for the screen. Inherits from ScreenIO to make sure all the

--- a/bluesky_gym/envs/descent_env.py
+++ b/bluesky_gym/envs/descent_env.py
@@ -2,7 +2,6 @@ import numpy as np
 import pygame
 
 import bluesky as bs
-from bluesky_gym.envs.common.screen_dummy import ScreenDummy
 
 import gymnasium as gym
 from gymnasium import spaces
@@ -68,8 +67,7 @@ class DescentEnv(gym.Env):
         if bs.sim is None:
             bs.init(mode='sim', detached=True)
 
-        # initialize dummy screen and set correct sim speed
-        bs.scr = ScreenDummy()
+        # set correct sim speed
         bs.stack.stack('DT 1;FF')
 
         # initialize values used for logging -> input in _get_info

--- a/bluesky_gym/envs/horizontal_cr_env.py
+++ b/bluesky_gym/envs/horizontal_cr_env.py
@@ -2,7 +2,6 @@ import numpy as np
 import pygame
 
 import bluesky as bs
-from bluesky_gym.envs.common.screen_dummy import ScreenDummy
 import bluesky_gym.envs.common.functions as fn
 
 import gymnasium as gym
@@ -68,8 +67,7 @@ class HorizontalCREnv(gym.Env):
         if bs.sim is None:
             bs.init(mode='sim', detached=True)
 
-        # initialize dummy screen and set correct sim speed
-        bs.scr = ScreenDummy()
+        # set correct sim speed
         bs.stack.stack('DT 5;FF')
 
         # initialize values used for logging -> input in _get_info

--- a/bluesky_gym/envs/merge_env.py
+++ b/bluesky_gym/envs/merge_env.py
@@ -2,7 +2,6 @@ import numpy as np
 import pygame
 
 import bluesky as bs
-from bluesky_gym.envs.common.screen_dummy import ScreenDummy
 import bluesky_gym.envs.common.functions as fn
 
 import gymnasium as gym
@@ -82,8 +81,7 @@ class MergeEnv(gym.Env):
         if bs.sim is None:
             bs.init(mode='sim', detached=True)
 
-        # initialize dummy screen and set correct sim speed
-        bs.scr = ScreenDummy()
+        # set correct sim speed
         bs.stack.stack('DT 5;FF')
 
         # initialize values used for logging -> input in _get_info

--- a/bluesky_gym/envs/plan_waypoint_env.py
+++ b/bluesky_gym/envs/plan_waypoint_env.py
@@ -2,7 +2,6 @@ import numpy as np
 import pygame
 
 import bluesky as bs
-from bluesky_gym.envs.common.screen_dummy import ScreenDummy
 import bluesky_gym.envs.common.functions as fn
 
 import gymnasium as gym
@@ -65,8 +64,7 @@ class PlanWaypointEnv(gym.Env):
         if bs.sim is None:
             bs.init(mode='sim', detached=True)
 
-        # initialize dummy screen and set correct sim speed
-        bs.scr = ScreenDummy()
+        # set correct sim speed
         bs.stack.stack('DT 1;FF')
 
         # initialize values used for logging -> input in _get_info

--- a/bluesky_gym/envs/sector_cr_env.py
+++ b/bluesky_gym/envs/sector_cr_env.py
@@ -2,7 +2,6 @@ import numpy as np
 import pygame
 
 import bluesky as bs
-from bluesky_gym.envs.common.screen_dummy import ScreenDummy
 import bluesky_gym.envs.common.functions as fn
 
 import gymnasium as gym
@@ -73,8 +72,7 @@ class SectorCREnv(gym.Env):
         if bs.sim is None:
             bs.init(mode='sim', detached=True)
 
-        # initialize dummy screen and set correct sim speed
-        bs.scr = ScreenDummy()
+        # set correct sim speed
         bs.stack.stack('DT 1;FF')
 
         # initialize values used for logging -> input in _get_info

--- a/bluesky_gym/envs/static_obstacle_env.py
+++ b/bluesky_gym/envs/static_obstacle_env.py
@@ -2,9 +2,7 @@ import numpy as np
 import pygame
 
 import bluesky as bs
-from bluesky_gym.envs.common.screen_dummy import ScreenDummy
 import bluesky_gym.envs.common.functions as fn
-from bluesky.tools.aero import kts
 
 import gymnasium as gym
 from gymnasium import spaces
@@ -79,8 +77,7 @@ class StaticObstacleEnv(gym.Env):
         if bs.sim is None:
             bs.init(mode='sim', detached=True)
 
-        # initialize dummy screen and set correct sim speed
-        bs.scr = ScreenDummy()
+        # set correct sim speed
         bs.stack.stack('DT 1;FF')
         
         # variables for logging

--- a/bluesky_gym/envs/vertical_cr_env.py
+++ b/bluesky_gym/envs/vertical_cr_env.py
@@ -2,7 +2,6 @@ import numpy as np
 import pygame
 
 import bluesky as bs
-from bluesky_gym.envs.common.screen_dummy import ScreenDummy
 import bluesky_gym.envs.common.functions as fn
 
 import gymnasium as gym
@@ -91,8 +90,7 @@ class VerticalCREnv(gym.Env):
         if bs.sim is None:
             bs.init(mode='sim', detached=True)
 
-        # initialize dummy screen and set correct sim speed
-        bs.scr = ScreenDummy()
+        # set correct sim speed
         bs.stack.stack('DT 1;FF')
 
         # initialize values used for logging -> input in _get_info


### PR DESCRIPTION
Subclassing `ScreenIO` in detached simulations is no longer necessary in BlueSky >= 1.0.0.