### PR TITLE
Refactor rendering

### DIFF
--- a/bluesky_gym/envs/descent_env.py
+++ b/bluesky_gym/envs/descent_env.py
@@ -1,12 +1,14 @@
 import numpy as np
-import pygame
-
 import bluesky as bs
 
 import gymnasium as gym
 from gymnasium import spaces
 
 from core.observations import OwnAltitudeObservation, TargetAltitudeObservation, RunwayDistanceObservation
+from core.rendering import (
+    PygameCanvas, SideProfileProjection,
+    draw_side_aircraft, draw_ground, draw_runway, draw_target_altitude,
+)
 
 ACTION_2_MS = 12.5
 
@@ -71,15 +73,11 @@ class DescentEnv(gym.Env):
         self.total_reward = 0
         self.final_altitude = 0
 
-        """
-        If human-rendering is used, `self.window` will be a reference
-        to the window that we draw to. `self.clock` will be a clock that is used
-        to ensure that the environment is rendered at the correct framerate in
-        human-mode. They will remain `None` until human-mode is used for the
-        first time.
-        """
-        self.window = None
-        self.clock = None
+        self.pygame_canvas = PygameCanvas(self.window_width, self.window_height)
+        self.projection = SideProfileProjection(
+            max_distance=180, max_altitude=5000,
+            window_size=(self.window_width, self.window_height),
+        )
 
 
     def _get_obs(self):
@@ -189,70 +187,20 @@ class DescentEnv(gym.Env):
         self.runway_distance = (
             200 - bs.tools.geo.kwikdist(52, 4, bs.traf.lat[0], bs.traf.lon[0]) * 1.852
         )
-        if self.window is None and self.render_mode == "human":
-            pygame.init()
-            pygame.display.init()
-            self.window = pygame.display.set_mode(self.window_size)
+        canvas = self.pygame_canvas.begin_frame()
 
-        if self.clock is None and self.render_mode == "human":
-            self.clock = pygame.time.Clock()
+        draw_ground(canvas, self.projection)
 
-        zero_offset = 25
-        max_distance = 180 # width of screen in km
+        _, target_y = self.projection.project(0, self.target_alt)
+        draw_target_altitude(canvas, target_y, self.projection)
 
-        canvas = pygame.Surface(self.window_size)
-        canvas.fill((135,206,235))
+        rwy_x, rwy_y = self.projection.project(self.runway_distance, 0)
+        draw_runway(canvas, rwy_x, rwy_y, self.projection.scale_horizontal(30))
 
-        # draw a ground surface
-        pygame.draw.rect(
-            canvas, 
-            (154,205,50),
-            pygame.Rect(
-                (0,self.window_height-50),
-                (self.window_width, 50)
-                ),
-        )
-        
-        # draw target altitude
-        max_alt = 5000
-        target_alt = int((-1*(self.target_alt-max_alt)/max_alt)*(self.window_height-50))
+        ac_x, ac_y = self.projection.project(0, self.altitude)
+        draw_side_aircraft(canvas, ac_x, ac_y, self.projection.scale_horizontal(4))
 
-        pygame.draw.line(
-            canvas,
-            (255,255,255),
-            (0,target_alt),
-            (self.window_width,target_alt)
-        )
-
-        # draw runway
-        runway_length = 30
-        runway_start = int(((self.runway_distance + zero_offset)/max_distance)*self.window_width)
-        runway_end = int(runway_start + (runway_length/max_distance)*self.window_width)
-
-        pygame.draw.line(
-            canvas,
-            (119,136,153),
-            (runway_start,self.window_height - 50),
-            (runway_end,self.window_height - 50),
-            width = 3
-        )
-
-        # draw aircraft
-        aircraft_alt = int((-1*(self.altitude-max_alt)/max_alt)*(self.window_height-50))
-        aircraft_start = int(((zero_offset)/max_distance)*self.window_width)
-        aircraft_end = int(aircraft_start + (4/max_distance)*self.window_width)
-
-        pygame.draw.line(
-            canvas,
-            (0,0,0),
-            (aircraft_start,aircraft_alt),
-            (aircraft_end,aircraft_alt),
-            width = 5
-        )
-
-        self.window.blit(canvas, canvas.get_rect())
-        pygame.display.update()
-        self.clock.tick(self.metadata["render_fps"])
+        self.pygame_canvas.end_frame(canvas)
         
     def close(self):
         bs.stack.stack('quit')

--- a/bluesky_gym/envs/horizontal_cr_env.py
+++ b/bluesky_gym/envs/horizontal_cr_env.py
@@ -1,7 +1,5 @@
 
 import numpy as np
-import pygame
-
 import bluesky as bs
 import bluesky_gym.envs.common.functions as fn
 
@@ -9,6 +7,10 @@ import gymnasium as gym
 from gymnasium import spaces
 
 from core.observations import IntruderObservation, WaypointObservation
+from core.rendering import (
+    PygameCanvas, TopDownProjection,
+    draw_aircraft, draw_intruder, draw_waypoint,
+)
 
 DISTANCE_MARGIN = 5 # km
 REACH_REWARD = 1
@@ -73,8 +75,11 @@ class HorizontalCREnv(gym.Env):
         self.total_intrusions = 0
         self.average_drift = np.array([])
 
-        self.window = None
-        self.clock = None
+        self.pygame_canvas = PygameCanvas(self.window_width, self.window_height)
+        self.projection = TopDownProjection(
+            max_distance=200, viewport=(0, 0, self.window_width, self.window_height),
+            ref_lat=0, ref_lon=0,
+        )
 
     def reset(self, seed=None, options=None):
         super().reset(seed=seed)
@@ -85,7 +90,7 @@ class HorizontalCREnv(gym.Env):
         self.total_intrusions = 0
         self.average_drift = np.array([])
 
-        bs.traf.cre(self.agent,actype="A320",acspd=AC_SPD)
+        bs.traf.cre(self.agent,actype="A320",acspd=AC_SPD,achdg=90)
 
         self._generate_conflicts()
         self._generate_waypoint()
@@ -135,7 +140,7 @@ class HorizontalCREnv(gym.Env):
         self.wpt_reach = []
         for i in range(NUM_WAYPOINTS):
             wpt_dis_init = np.random.randint(WAYPOINT_DISTANCE_MIN, WAYPOINT_DISTANCE_MAX)
-            wpt_hdg_init = 0
+            wpt_hdg_init = 90
 
             ac_idx = bs.traf.id2idx(acid)
 
@@ -226,124 +231,30 @@ class HorizontalCREnv(gym.Env):
         bs.stack.stack(f"HDG KL001 {action[0]}")
 
     def _render_frame(self):
-        if self.window is None and self.render_mode == "human":
-            pygame.init()
-            pygame.display.init()
-            self.window = pygame.display.set_mode(self.window_size)
-
-        if self.clock is None and self.render_mode == "human":
-            self.clock = pygame.time.Clock()
-
-        max_distance = 200 # width of screen in km
-
-        canvas = pygame.Surface(self.window_size)
-        canvas.fill((135,206,235))
-
-        # draw ownship
         ac_idx = bs.traf.id2idx('KL001')
-        ac_length = 8
-        heading_end_x = ((np.cos(np.deg2rad(bs.traf.hdg[ac_idx])) * ac_length)/max_distance)*self.window_width
-        heading_end_y = ((np.sin(np.deg2rad(bs.traf.hdg[ac_idx])) * ac_length)/max_distance)*self.window_width
+        self.projection.update_ref(bs.traf.lat[ac_idx], bs.traf.lon[ac_idx])
+        canvas = self.pygame_canvas.begin_frame()
 
-        pygame.draw.line(canvas,
-            (0,0,0),
-            (self.window_width/2-heading_end_x/2,self.window_height/2+heading_end_y/2),
-            ((self.window_width/2)+heading_end_x/2,(self.window_height/2)-heading_end_y/2),
-            width = 4
-        )
-
-        # draw heading line
-        heading_length = 50
-        heading_end_x = ((np.cos(np.deg2rad(bs.traf.hdg[ac_idx])) * heading_length)/max_distance)*self.window_width
-        heading_end_y = ((np.sin(np.deg2rad(bs.traf.hdg[ac_idx])) * heading_length)/max_distance)*self.window_width
-
-        pygame.draw.line(canvas,
-            (0,0,0),
-            (self.window_width/2,self.window_height/2),
-            ((self.window_width/2)+heading_end_x,(self.window_height/2)-heading_end_y),
-            width = 1
-        )
-
-        # draw intruders
-        ac_length = 3
+        draw_aircraft(canvas, *self.projection.center, bs.traf.hdg[ac_idx],
+                      body_km=8, heading_km=50, projection=self.projection)
 
         for i in range(NUM_INTRUDERS):
-            int_idx = i+1
-            int_hdg = bs.traf.hdg[int_idx]
-            heading_end_x = ((np.cos(np.deg2rad(int_hdg)) * ac_length)/max_distance)*self.window_width
-            heading_end_y = ((np.sin(np.deg2rad(int_hdg)) * ac_length)/max_distance)*self.window_width
+            int_idx = i + 1
+            x, y = self.projection.project(bs.traf.lat[int_idx], bs.traf.lon[int_idx])
+            int_dis = bs.tools.geo.kwikdist(
+                bs.traf.lat[ac_idx], bs.traf.lon[ac_idx],
+                bs.traf.lat[int_idx], bs.traf.lon[int_idx])
+            draw_intruder(canvas, x, y, bs.traf.hdg[int_idx], self.projection,
+                          body_km=3, heading_km=10,
+                          safety_radius_km=INTRUSION_DISTANCE * NM2KM,
+                          in_intrusion=int_dis < INTRUSION_DISTANCE)
 
-            int_qdr, int_dis = bs.tools.geo.kwikqdrdist(bs.traf.lat[ac_idx], bs.traf.lon[ac_idx], bs.traf.lat[int_idx], bs.traf.lon[int_idx])
+        for lat, lon, reached in zip(self.wpt_lat, self.wpt_lon, self.wpt_reach):
+            x, y = self.projection.project(lat, lon)
+            draw_waypoint(canvas, x, y, DISTANCE_MARGIN, self.projection,
+                          reached=bool(reached))
 
-            # determine color
-            if int_dis < INTRUSION_DISTANCE:
-                color = (220,20,60)
-            else: 
-                color = (80,80,80)
-
-            x_pos = (self.window_width/2)+(np.cos(np.deg2rad(int_qdr))*(int_dis * NM2KM)/max_distance)*self.window_width
-            y_pos = (self.window_height/2)-(np.sin(np.deg2rad(int_qdr))*(int_dis * NM2KM)/max_distance)*self.window_height
-
-            pygame.draw.line(canvas,
-                color,
-                (x_pos,y_pos),
-                ((x_pos)+heading_end_x,(y_pos)-heading_end_y),
-                width = 4
-            )
-
-            # draw heading line
-            heading_length = 10
-            heading_end_x = ((np.cos(np.deg2rad(int_hdg)) * heading_length)/max_distance)*self.window_width
-            heading_end_y = ((np.sin(np.deg2rad(int_hdg)) * heading_length)/max_distance)*self.window_width
-
-            pygame.draw.line(canvas,
-                color,
-                (x_pos,y_pos),
-                ((x_pos)+heading_end_x,(y_pos)-heading_end_y),
-                width = 1
-            )
-
-            pygame.draw.circle(
-                canvas, 
-                color,
-                (x_pos,y_pos),
-                radius = (INTRUSION_DISTANCE*NM2KM/max_distance)*self.window_width,
-                width = 2
-            )
-
-            # import code
-            # code.interact(local=locals())
-
-        # draw target waypoint
-        for qdr, dis, reach in zip(self.wpt_qdr, self.waypoint_distance, self.wpt_reach):
-
-            circle_x = ((np.cos(np.deg2rad(qdr)) * dis)/max_distance)*self.window_width
-            circle_y = ((np.sin(np.deg2rad(qdr)) * dis)/max_distance)*self.window_width
-
-            if reach:
-                color = (155,155,155)
-            else:
-                color = (255,255,255)
-
-            pygame.draw.circle(
-                canvas, 
-                color,
-                ((self.window_width/2)+circle_x,(self.window_height/2)-circle_y),
-                radius = 4,
-                width = 0
-            )
-            
-            pygame.draw.circle(
-                canvas, 
-                color,
-                ((self.window_width/2)+circle_x,(self.window_height/2)-circle_y),
-                radius = (DISTANCE_MARGIN/max_distance)*self.window_width,
-                width = 2
-            )
-
-        self.window.blit(canvas, canvas.get_rect())
-        pygame.display.update()
-        self.clock.tick(self.metadata["render_fps"])
+        self.pygame_canvas.end_frame(canvas)
         
     def close(self):
         bs.stack.stack('quit')

--- a/bluesky_gym/envs/horizontal_cr_env.py
+++ b/bluesky_gym/envs/horizontal_cr_env.py
@@ -77,8 +77,8 @@ class HorizontalCREnv(gym.Env):
 
         self.pygame_canvas = PygameCanvas(self.window_width, self.window_height)
         self.projection = TopDownProjection(
-            max_distance=200, viewport=(0, 0, self.window_width, self.window_height),
-            ref_lat=0, ref_lon=0,
+            max_distance=200, ref_lat=0, ref_lon=0,
+            window_size=(self.window_width, self.window_height),
         )
 
     def reset(self, seed=None, options=None):

--- a/bluesky_gym/envs/merge_env.py
+++ b/bluesky_gym/envs/merge_env.py
@@ -1,8 +1,6 @@
 # TODO: change faf_reached to standardized waypoint reached approach (building on waypoint observation functionality)
 
 import numpy as np
-import pygame
-
 import bluesky as bs
 import bluesky_gym.envs.common.functions as fn
 
@@ -12,6 +10,11 @@ from gymnasium import spaces
 import random
 
 from core.observations import DriftObservation, OwnAirspeedObservation, WaypointObservation, IntruderObservation
+from core.rendering import (
+    PygameCanvas, TopDownProjection,
+    draw_aircraft, draw_intruder, draw_waypoint, draw_radial_line, draw_line,
+    BLACK, WHITE, BRIGHT_GREEN,
+)
 
 DISTANCE_MARGIN = 10 # km
 REACH_REWARD = 1
@@ -45,8 +48,8 @@ RWY_LAT = 52.36239301495972
 RWY_LON = 4.713195734579777
 
 distance_faf_rwy = 200 # NM
-bearing_faf_rwy = 0
-FIX_LAT, FIX_LON = fn.get_point_at_distance(RWY_LAT, RWY_LON, distance_faf_rwy, bearing_faf_rwy)
+FIX_LAT = RWY_LAT
+FIX_LON = RWY_LON + (distance_faf_rwy / 60) / np.cos(np.radians(RWY_LAT))
 
 class MergeEnv(gym.Env):
     """ 
@@ -93,8 +96,11 @@ class MergeEnv(gym.Env):
         self.total_intrusions = 0
         self.faf_reached = 0
 
-        self.window = None
-        self.clock = None
+        self.pygame_canvas = PygameCanvas(self.window_width, self.window_height)
+        self.projection = TopDownProjection(
+            max_distance=500, ref_lat=FIX_LAT, ref_lon=FIX_LON,
+            window_size=(self.window_width, self.window_height),
+        )
         self.nac = NUM_AC
         self.wpt_reach = 0
         self.wpt_lat = FIX_LAT
@@ -113,12 +119,12 @@ class MergeEnv(gym.Env):
         self.total_intrusions = 0
         self.faf_reached = 0
 
-        # ownship spawn location
-        bearing_to_pos = random.uniform(-D_HEADING, D_HEADING) # heading radial towards FAF
-        distance_to_pos = random.uniform(SPAWN_DISTANCE_MIN,SPAWN_DISTANCE_MAX)  # distance to faf 
+        # ownship spawn location (east of FAF, heading west toward it)
+        bearing_to_pos = 90 + random.uniform(-D_HEADING, D_HEADING)
+        distance_to_pos = random.uniform(SPAWN_DISTANCE_MIN, SPAWN_DISTANCE_MAX)
         rlat, rlon = fn.get_point_at_distance(FIX_LAT, FIX_LON, distance_to_pos, bearing_to_pos)
 
-        bs.traf.cre(self.agent,actype="A320",acspd=AC_SPD, aclat= rlat, aclon= rlon, achdg=bearing_to_pos-180,acalt=10000)
+        bs.traf.cre(self.agent, actype="A320", acspd=AC_SPD, aclat=rlat, aclon=rlon, achdg=bearing_to_pos - 180, acalt=10000)
 
         # generate other aircraft
         self._gen_aircraft()
@@ -149,11 +155,11 @@ class MergeEnv(gym.Env):
     
     def _gen_aircraft(self):
         for i in range(NUM_AC-1):
-            bearing_to_pos = random.uniform(-D_HEADING, D_HEADING) # heading radial towards FAF
-            distance_to_pos = random.uniform(INTRUDER_DISTANCE_MIN,INTRUDER_DISTANCE_MAX) # distance to faf 
+            bearing_to_pos = 90 + random.uniform(-D_HEADING, D_HEADING)
+            distance_to_pos = random.uniform(INTRUDER_DISTANCE_MIN, INTRUDER_DISTANCE_MAX)
             lat_ac, lon_ac = fn.get_point_at_distance(self.wpt_lat, self.wpt_lon, distance_to_pos, bearing_to_pos)
 
-            bs.traf.cre(f'INT{i}',actype="A320",acspd=AC_SPD,aclat=lat_ac,aclon=lon_ac,achdg=bearing_to_pos-180,acalt=10000)
+            bs.traf.cre(f'INT{i}', actype="A320", acspd=AC_SPD, aclat=lat_ac, aclon=lon_ac, achdg=bearing_to_pos - 180, acalt=10000)
             bs.stack.stack(f"INT{i} addwpt {FIX_LAT} {FIX_LON}")
             bs.stack.stack(f"INT{i} dest {RWY_LAT} {RWY_LON}")
         bs.stack.stack('reso off')
@@ -239,162 +245,42 @@ class MergeEnv(gym.Env):
         bs.stack.stack(f"SPD KL001 {speed_new}")
         
     def _render_frame(self):
-        if self.window is None and self.render_mode == "human":
-            pygame.init()
-            pygame.display.init()
-            self.window = pygame.display.set_mode(self.window_size)
-
-        if self.clock is None and self.render_mode == "human":
-            self.clock = pygame.time.Clock()
-
-        max_distance = 500 # width of screen in km
-
-        canvas = pygame.Surface(self.window_size)
-        canvas.fill((135,206,235)) 
-
-        circle_x = self.window_width/2
-        circle_y = self.window_height/2
-
-        pygame.draw.circle(
-            canvas, 
-            (255,255,255),
-            (circle_x,circle_y),
-            radius = 4,
-            width = 0
-        )
-        
-        pygame.draw.circle(
-            canvas, 
-            (255,255,255),
-            (circle_x,circle_y),
-            radius = (DISTANCE_MARGIN/max_distance)*self.window_width,
-            width = 2
-        )
-
-        # draw line to faf
-        heading_length = 5000
-        heading_end_x = ((np.cos(np.deg2rad(180)) * heading_length)/max_distance)*self.window_width
-        heading_end_y = ((np.sin(np.deg2rad(180)) * heading_length)/max_distance)*self.window_width
-        pygame.draw.line(canvas,
-        (0,0,0),
-        (circle_x,circle_y),
-        (circle_x+heading_end_x/2,circle_y-heading_end_y/2),
-        width = 2
-        )
-
-        # heading boundary lines
-        he_x_l = ((np.cos(np.deg2rad(180+135)) * heading_length)/max_distance)*self.window_width
-        he_y_l = ((np.sin(np.deg2rad(180+135)) * heading_length)/max_distance)*self.window_width
-        he_x_r = ((np.cos(np.deg2rad(180-135)) * heading_length)/max_distance)*self.window_width
-        he_y_r = ((np.sin(np.deg2rad(180-135)) * heading_length)/max_distance)*self.window_width
-        pygame.draw.line(canvas,
-        (3,252,11),
-        (circle_x,circle_y),
-        (circle_x+he_x_l/2,circle_y-he_y_l/2),
-        width = 4
-        )
-        pygame.draw.line(canvas,
-        (3,252,11),
-        (circle_x,circle_y),
-        (circle_x+he_x_r/2,circle_y-he_y_r/2),
-        width = 4
-        )
-
-        # draw rwy start
-        rwy_faf_qdr, rwy_faf_dis = bs.tools.geo.kwikqdrdist(self.wpt_lat, self.wpt_lon, RWY_LAT, RWY_LON)
-        x_pos = (circle_x)+(np.cos(np.deg2rad(rwy_faf_qdr))*(rwy_faf_dis * NM2KM)/max_distance)*self.window_width
-        y_pos = (circle_y)-(np.sin(np.deg2rad(rwy_faf_qdr))*(rwy_faf_dis * NM2KM)/max_distance)*self.window_height
-        heading_length = 5000
-        heading_end_x = ((np.cos(np.deg2rad(180)) * heading_length)/max_distance)*self.window_width
-        heading_end_y = ((np.sin(np.deg2rad(180)) * heading_length)/max_distance)*self.window_width
-        pygame.draw.line(canvas,
-        (255,255,255),
-        (x_pos,y_pos),
-        (circle_x+heading_end_x/2,circle_y-heading_end_y/2),
-        width = 4
-        )
-
-        # draw ownship
         ac_idx = bs.traf.id2idx('KL001')
-        ac_length = 8
-        heading_end_x = ((np.cos(np.deg2rad(bs.traf.hdg[ac_idx])) * ac_length)/max_distance)*self.window_width
-        heading_end_y = ((np.sin(np.deg2rad(bs.traf.hdg[ac_idx])) * ac_length)/max_distance)*self.window_width
+        canvas = self.pygame_canvas.begin_frame()
+        cx, cy = self.projection.center
 
-        own_qdr, own_dis = bs.tools.geo.kwikqdrdist(self.wpt_lat, self.wpt_lon, bs.traf.lat[ac_idx], bs.traf.lon[ac_idx])
-        x_pos = (circle_x)+(np.cos(np.deg2rad(own_qdr))*(own_dis * NM2KM)/max_distance)*self.window_width
-        y_pos = (circle_y)-(np.sin(np.deg2rad(own_qdr))*(own_dis * NM2KM)/max_distance)*self.window_height
-        pygame.draw.line(canvas,
-            (0,0,0),
-            (x_pos,y_pos),
-            ((x_pos)+heading_end_x/2,(y_pos)-heading_end_y/2),
-            width = 4
-        )
+        # FAF waypoint at center
+        draw_waypoint(canvas, cx, cy, DISTANCE_MARGIN, self.projection)
 
-        # draw heading line
-        heading_length = 10
-        heading_end_x = ((np.cos(np.deg2rad(bs.traf.hdg[ac_idx])) * heading_length)/max_distance)*self.window_width
-        heading_end_y = ((np.sin(np.deg2rad(bs.traf.hdg[ac_idx])) * heading_length)/max_distance)*self.window_width
+        # Approach corridor: center line + boundary lines
+        draw_radial_line(canvas, cx, cy, 270, length_km=5000, projection=self.projection,
+                         color=BLACK, width=2)
+        draw_radial_line(canvas, cx, cy, 270 + 135, length_km=5000, projection=self.projection,
+                         color=BRIGHT_GREEN, width=4)
+        draw_radial_line(canvas, cx, cy, 270 - 135, length_km=5000, projection=self.projection,
+                         color=BRIGHT_GREEN, width=4)
 
-        pygame.draw.line(canvas,
-            (0,0,0),
-            (x_pos,y_pos),
-            ((x_pos)+heading_end_x,(y_pos)-heading_end_y),
-            width = 1
-        )
+        # Runway line
+        rwy_x, rwy_y = self.projection.project(RWY_LAT, RWY_LON)
+        draw_line(canvas, cx, cy, rwy_x, rwy_y, color=WHITE, width=4)
 
-        # draw intruders
-        ac_length = 3
+        # Ownship
+        x, y = self.projection.project(bs.traf.lat[ac_idx], bs.traf.lon[ac_idx])
+        draw_aircraft(canvas, x, y, bs.traf.hdg[ac_idx],
+                      body_km=8, heading_km=10, projection=self.projection)
 
-        for i in range(1,NUM_AC):
-            int_idx = i
-            int_hdg = bs.traf.hdg[int_idx]
-            heading_end_x = ((np.cos(np.deg2rad(int_hdg)) * ac_length)/max_distance)*self.window_width
-            heading_end_y = ((np.sin(np.deg2rad(int_hdg)) * ac_length)/max_distance)*self.window_width
+        # Intruders
+        for i in range(1, NUM_AC):
+            ix, iy = self.projection.project(bs.traf.lat[i], bs.traf.lon[i])
+            separation = bs.tools.geo.kwikdist(
+                bs.traf.lat[ac_idx], bs.traf.lon[ac_idx],
+                bs.traf.lat[i], bs.traf.lon[i])
+            draw_intruder(canvas, ix, iy, bs.traf.hdg[i], self.projection,
+                          body_km=3, heading_km=10,
+                          safety_radius_km=INTRUSION_DISTANCE * NM2KM,
+                          in_intrusion=separation < INTRUSION_DISTANCE)
 
-            int_qdr, int_dis = bs.tools.geo.kwikqdrdist(self.wpt_lat, self.wpt_lon, bs.traf.lat[int_idx], bs.traf.lon[int_idx])
-
-            # determine color
-            if int_dis < INTRUSION_DISTANCE:
-                color = (220,20,60)
-            else: 
-                color = (80,80,80)
-            if i==0:
-                color = (252, 43, 28)
-
-            x_pos = (circle_x)+(np.cos(np.deg2rad(int_qdr))*(int_dis * NM2KM)/max_distance)*self.window_width
-            y_pos = (circle_y)-(np.sin(np.deg2rad(int_qdr))*(int_dis * NM2KM)/max_distance)*self.window_height
-
-            pygame.draw.line(canvas,
-                color,
-                (x_pos,y_pos),
-                ((x_pos)+heading_end_x,(y_pos)-heading_end_y),
-                width = 4
-            )
-
-            # draw heading line
-            heading_length = 10
-            heading_end_x = ((np.cos(np.deg2rad(int_hdg)) * heading_length)/max_distance)*self.window_width
-            heading_end_y = ((np.sin(np.deg2rad(int_hdg)) * heading_length)/max_distance)*self.window_width
-
-            pygame.draw.line(canvas,
-                color,
-                (x_pos,y_pos),
-                ((x_pos)+heading_end_x,(y_pos)-heading_end_y),
-                width = 1
-            )
-
-            pygame.draw.circle(
-                canvas, 
-                color,
-                (x_pos,y_pos),
-                radius = (INTRUSION_DISTANCE*NM2KM/max_distance)*self.window_width,
-                width = 2
-            )
-
-        # PyGame update
-        self.window.blit(canvas, canvas.get_rect())
-        pygame.display.update()
-        self.clock.tick(self.metadata["render_fps"])
+        self.pygame_canvas.end_frame(canvas)
         
     def close(self):
         bs.stack.stack('quit')

--- a/bluesky_gym/envs/plan_waypoint_env.py
+++ b/bluesky_gym/envs/plan_waypoint_env.py
@@ -74,8 +74,8 @@ class PlanWaypointEnv(gym.Env):
 
         self.pygame_canvas = PygameCanvas(self.window_width, self.window_height)
         self.projection = TopDownProjection(
-            max_distance=200, viewport=(0, 0, self.window_width, self.window_height),
-            ref_lat=0, ref_lon=0,
+            max_distance=200, ref_lat=0, ref_lon=0,
+            window_size=(self.window_width, self.window_height),
         )
 
 

--- a/bluesky_gym/envs/plan_waypoint_env.py
+++ b/bluesky_gym/envs/plan_waypoint_env.py
@@ -1,6 +1,4 @@
 import numpy as np
-import pygame
-
 import bluesky as bs
 import bluesky_gym.envs.common.functions as fn
 
@@ -8,6 +6,7 @@ import gymnasium as gym
 from gymnasium import spaces
 
 from core.observations import WaypointObservation
+from core.rendering import PygameCanvas, TopDownProjection, draw_aircraft, draw_waypoint
 
 DISTANCE_MARGIN = 5 # km
 WAYPOINT_DISTANCE_MIN = 0
@@ -73,15 +72,11 @@ class PlanWaypointEnv(gym.Env):
         self.total_reward = 0
         self.waypoints_completed = 0
 
-        """
-        If human-rendering is used, `self.window` will be a reference
-        to the window that we draw to. `self.clock` will be a clock that is used
-        to ensure that the environment is rendered at the correct framerate in
-        human-mode. They will remain `None` until human-mode is used for the
-        first time.
-        """
-        self.window = None
-        self.clock = None
+        self.pygame_canvas = PygameCanvas(self.window_width, self.window_height)
+        self.projection = TopDownProjection(
+            max_distance=200, viewport=(0, 0, self.window_width, self.window_height),
+            ref_lat=0, ref_lon=0,
+        )
 
 
     def _get_obs(self):
@@ -205,74 +200,19 @@ class PlanWaypointEnv(gym.Env):
         return reward
 
     def _render_frame(self):
-        if self.window is None and self.render_mode == "human":
-            pygame.init()
-            pygame.display.init()
-            self.window = pygame.display.set_mode(self.window_size)
-
-        if self.clock is None and self.render_mode == "human":
-            self.clock = pygame.time.Clock()
-
-        max_distance = 200 # width of screen in km
-
-        canvas = pygame.Surface(self.window_size)
-        canvas.fill((135,206,235))
-
-        # draw ownship
         ac_idx = bs.traf.id2idx('KL001')
-        ac_length = 8
-        heading_end_x = ((np.cos(np.deg2rad(bs.traf.hdg[ac_idx])) * ac_length)/max_distance)*self.window_width
-        heading_end_y = ((np.sin(np.deg2rad(bs.traf.hdg[ac_idx])) * ac_length)/max_distance)*self.window_width
+        self.projection.update_ref(bs.traf.lat[ac_idx], bs.traf.lon[ac_idx])
+        canvas = self.pygame_canvas.begin_frame()
 
-        pygame.draw.line(canvas,
-            (0,0,0),
-            (self.window_width/2,self.window_height/2),
-            ((self.window_width/2)+heading_end_x,(self.window_height/2)-heading_end_y),
-            width = 4
-        )
+        draw_aircraft(canvas, *self.projection.center, bs.traf.hdg[ac_idx],
+                      body_km=8, heading_km=50, projection=self.projection)
 
-        # draw heading line
-        heading_length = 50
-        heading_end_x = ((np.cos(np.deg2rad(bs.traf.hdg[ac_idx])) * heading_length)/max_distance)*self.window_width
-        heading_end_y = ((np.sin(np.deg2rad(bs.traf.hdg[ac_idx])) * heading_length)/max_distance)*self.window_width
+        for lat, lon, reached in zip(self.wpt_lat, self.wpt_lon, self.wpt_reach):
+            x, y = self.projection.project(lat, lon)
+            draw_waypoint(canvas, x, y, DISTANCE_MARGIN, self.projection,
+                          reached=bool(reached))
 
-        pygame.draw.line(canvas,
-            (0,0,0),
-            (self.window_width/2,self.window_height/2),
-            ((self.window_width/2)+heading_end_x,(self.window_height/2)-heading_end_y),
-            width = 1
-        )
-
-        # draw target waypoint
-        for qdr, dis, reach in zip(self.wpt_qdr, self.wpt_dis, self.wpt_reach):
-
-            circle_x = ((np.cos(np.deg2rad(qdr)) * dis)/max_distance)*self.window_width
-            circle_y = ((np.sin(np.deg2rad(qdr)) * dis)/max_distance)*self.window_width
-
-            if reach:
-                color = (155,155,155)
-            else:
-                color = (255,255,255)
-
-            pygame.draw.circle(
-                canvas, 
-                color,
-                ((self.window_width/2)+circle_x,(self.window_height/2)-circle_y),
-                radius = 4,
-                width = 0
-            )
-            
-            pygame.draw.circle(
-                canvas, 
-                color,
-                ((self.window_width/2)+circle_x,(self.window_height/2)-circle_y),
-                radius = (DISTANCE_MARGIN/max_distance)*self.window_width,
-                width = 2
-            )
-
-        self.window.blit(canvas, canvas.get_rect())
-        pygame.display.update()
-        self.clock.tick(self.metadata["render_fps"])
+        self.pygame_canvas.end_frame(canvas)
         
     def close(self):
         bs.stack.stack('quit')

--- a/bluesky_gym/envs/sector_cr_env.py
+++ b/bluesky_gym/envs/sector_cr_env.py
@@ -82,8 +82,8 @@ class SectorCREnv(gym.Env):
 
         self.pygame_canvas = PygameCanvas(self.window_width, self.window_height)
         self.projection = TopDownProjection(
-            max_distance=200, viewport=(0, 0, self.window_width, self.window_height),
-            ref_lat=CENTER[0], ref_lon=CENTER[1],
+            max_distance=200, ref_lat=CENTER[0], ref_lon=CENTER[1],
+            window_size=(self.window_width, self.window_height),
         )
     
     def reset(self, seed=None, options=None):
@@ -102,9 +102,8 @@ class SectorCREnv(gym.Env):
             for p1 in self.poly_points for p2 in self.poly_points
         ) * NM2KM
         self.projection = TopDownProjection(
-            max_distance=max_distance,
-            viewport=(0, 0, self.window_width, self.window_height),
-            ref_lat=CENTER[0], ref_lon=CENTER[1],
+            max_distance=max_distance, ref_lat=CENTER[0], ref_lon=CENTER[1],
+            window_size=(self.window_width, self.window_height),
         )
         
         if self.density_mode == "normal":

--- a/bluesky_gym/envs/sector_cr_env.py
+++ b/bluesky_gym/envs/sector_cr_env.py
@@ -1,6 +1,4 @@
 import numpy as np
-import pygame
-
 import bluesky as bs
 import bluesky_gym.envs.common.functions as fn
 
@@ -8,6 +6,10 @@ import gymnasium as gym
 from gymnasium import spaces
 
 from core.observations import DriftObservation, OwnAirspeedObservation, IntruderObservation
+from core.rendering import (
+    PygameCanvas, TopDownProjection,
+    draw_aircraft, draw_intruder, draw_polygon,
+)
 
 AC_DENSITY_RANGE = (0.003, 0.007) # In AC/NM^2
 AC_DENSITY_MU = 0.003 # In AC/NM^2
@@ -61,7 +63,7 @@ class SectorCREnv(gym.Env):
 
         self.agent = "KL001"
 
-        self.action_space = spaces.Box(-1, 1, shape=(1,), dtype=np.float64)
+        self.action_space = spaces.Box(-1, 1, shape=(2,), dtype=np.float64)
 
         assert render_mode is None or render_mode in self.metadata["render_modes"]
         self.render_mode = render_mode
@@ -78,8 +80,11 @@ class SectorCREnv(gym.Env):
         self.total_intrusions = 0
         self.average_drift = np.array([])
 
-        self.window = None
-        self.clock = None
+        self.pygame_canvas = PygameCanvas(self.window_width, self.window_height)
+        self.projection = TopDownProjection(
+            max_distance=200, viewport=(0, 0, self.window_width, self.window_height),
+            ref_lat=CENTER[0], ref_lon=CENTER[1],
+        )
     
     def reset(self, seed=None, options=None):
         bs.traf.reset()
@@ -91,6 +96,16 @@ class SectorCREnv(gym.Env):
         self.average_drift = np.array([])
        
         self._generate_polygon() # Create airspace polygon
+
+        max_distance = max(
+            np.linalg.norm(p1 - p2)
+            for p1 in self.poly_points for p2 in self.poly_points
+        ) * NM2KM
+        self.projection = TopDownProjection(
+            max_distance=max_distance,
+            viewport=(0, 0, self.window_width, self.window_height),
+            ref_lat=CENTER[0], ref_lon=CENTER[1],
+        )
         
         if self.density_mode == "normal":
             rand_density = np.random.normal(AC_DENSITY_MU, AC_DENSITY_SIGMA)
@@ -246,12 +261,12 @@ class SectorCREnv(gym.Env):
         }
     
     def _get_action(self, action):
-        # dh = action[0] * D_HEADING
-        dv = action[0] * D_VELOCITY
-        # heading_new = fn.bound_angle_positive_negative_180(bs.traf.hdg[bs.traf.id2idx(self.agent)] + dh)
+        dh = action[0] * D_HEADING
+        dv = action[1] * D_VELOCITY
+        heading_new = fn.bound_angle_positive_negative_180(bs.traf.hdg[bs.traf.id2idx(self.agent)] + dh)
         speed_new = (bs.traf.cas[bs.traf.id2idx(self.agent)] + dv) * MpS2Kt
 
-        # bs.stack.stack(f"HDG {self.agent} {heading_new}")
+        bs.stack.stack(f"HDG {self.agent} {heading_new}")
         bs.stack.stack(f"SPD {self.agent} {speed_new}")
 
     def _check_drift(self):
@@ -272,107 +287,34 @@ class SectorCREnv(gym.Env):
         return reward
         
     def _render_frame(self):
-        if self.window is None and self.render_mode == "human":
-            pygame.init()
-            pygame.display.init()
-            self.window = pygame.display.set_mode(self.window_size)
+        ac_idx = bs.traf.id2idx(self.agent)
+        canvas = self.pygame_canvas.begin_frame()
 
-        if self.clock is None and self.render_mode == "human":
-            self.clock = pygame.time.Clock()
-
-        max_distance = max(np.linalg.norm(point1 - point2) for point1 in self.poly_points for point2 in self.poly_points)*NM2KM
-        
-        px_per_km = self.window_width/max_distance
-
-        canvas = pygame.Surface(self.window_size)
-        canvas.fill((135,206,235))
-        
-        # Draw airspace
-        airspace_color = (255, 0, 0)
-        coords = [((self.window_width/2)+point[0]*NM2KM*px_per_km, (self.window_height/2)-point[1]*NM2KM*px_per_km) for point in self.poly_points]
-        pygame.draw.polygon(canvas, airspace_color, coords, width=2)
+        # Draw airspace polygon
+        poly_coords = [
+            self.projection.project(*fn.nm_to_latlong(CENTER, pt))
+            for pt in self.poly_points
+        ]
+        draw_polygon(canvas, poly_coords, color=(255, 0, 0), filled=False, width=2)
 
         # Draw ownship
-        ac_idx = bs.traf.id2idx(self.agent)
-        ac_length = 10
-        ac_hdg = bs.traf.hdg[ac_idx]
-        heading_end_x = np.cos(np.deg2rad(ac_hdg)) * ac_length
-        heading_end_y = np.sin(np.deg2rad(ac_hdg)) * ac_length
-        ac_qdr, ac_dis = bs.tools.geo.kwikqdrdist(CENTER[0], CENTER[1], bs.traf.lat[ac_idx], bs.traf.lon[ac_idx])
-
-        x_pos = (self.window_width/2)+(np.cos(np.deg2rad(ac_qdr))*(ac_dis * NM2KM)*px_per_km)
-        y_pos = (self.window_height/2)-(np.sin(np.deg2rad(ac_qdr))*(ac_dis * NM2KM)*px_per_km)
-
-        pygame.draw.line(canvas,
-            (0,0,0),
-            (x_pos,y_pos),
-            ((x_pos)+heading_end_x,(y_pos)-heading_end_y),
-            width = 4
-        )
-
-        # Draw heading line
-        heading_length = 20
-        heading_end_x = np.cos(np.deg2rad(ac_hdg)) * heading_length
-        heading_end_y = np.sin(np.deg2rad(ac_hdg)) * heading_length
-
-        pygame.draw.line(canvas,
-                (0,0,0),
-                (x_pos,y_pos),
-                ((x_pos)+heading_end_x,(y_pos)-heading_end_y),
-                width = 1
-        )
+        x, y = self.projection.project(bs.traf.lat[ac_idx], bs.traf.lon[ac_idx])
+        draw_aircraft(canvas, x, y, bs.traf.hdg[ac_idx],
+                      body_km=3, heading_km=10, projection=self.projection)
 
         # Draw intruders
-        ac_length = 3
+        for i in range(self.num_ac - 1):
+            int_idx = i + 1
+            ix, iy = self.projection.project(bs.traf.lat[int_idx], bs.traf.lon[int_idx])
+            separation = bs.tools.geo.kwikdist(
+                bs.traf.lat[ac_idx], bs.traf.lon[ac_idx],
+                bs.traf.lat[int_idx], bs.traf.lon[int_idx])
+            draw_intruder(canvas, ix, iy, bs.traf.hdg[int_idx], self.projection,
+                          body_km=2, heading_km=5,
+                          safety_radius_km=INTRUSION_DISTANCE * NM2KM,
+                          in_intrusion=separation < INTRUSION_DISTANCE)
 
-        for i in range(self.num_ac-1):
-            int_idx = i+1
-            int_hdg = bs.traf.hdg[int_idx]
-            heading_end_x = np.cos(np.deg2rad(int_hdg)) * ac_length
-            heading_end_y = np.sin(np.deg2rad(int_hdg)) * ac_length
-
-            int_qdr, int_dis = bs.tools.geo.kwikqdrdist(CENTER[0], CENTER[1], bs.traf.lat[int_idx], bs.traf.lon[int_idx])
-            separation = bs.tools.geo.kwikdist(bs.traf.lat[ac_idx], bs.traf.lon[ac_idx], bs.traf.lat[int_idx], bs.traf.lon[int_idx])
-
-            # Determine color
-            if separation < INTRUSION_DISTANCE:
-                color = (220,20,60)
-            else: 
-                color = (80,80,80)
-
-            x_pos = (self.window_width/2)+(np.cos(np.deg2rad(int_qdr))*(int_dis * NM2KM)*px_per_km)
-            y_pos = (self.window_height/2)-(np.sin(np.deg2rad(int_qdr))*(int_dis * NM2KM)*px_per_km)
-
-            pygame.draw.line(canvas,
-                color,
-                (x_pos,y_pos),
-                ((x_pos)+heading_end_x,(y_pos)-heading_end_y),
-                width = 4
-            )
-
-            # Draw heading line
-            heading_length = 20
-            heading_end_x = np.cos(np.deg2rad(int_hdg)) * heading_length
-            heading_end_y = np.sin(np.deg2rad(int_hdg)) * heading_length
-
-            pygame.draw.line(canvas,
-                color,
-                (x_pos,y_pos),
-                ((x_pos)+heading_end_x,(y_pos)-heading_end_y),
-                width = 1
-            )
-
-            pygame.draw.circle(
-                canvas, 
-                color,
-                (x_pos,y_pos),
-                radius = INTRUSION_DISTANCE*NM2KM*px_per_km,
-                width = 2
-            )
-
-        self.window.blit(canvas, canvas.get_rect())
-        pygame.display.update()
-        self.clock.tick(self.metadata["render_fps"])
+        self.pygame_canvas.end_frame(canvas)
     
     def close(self):
         bs.stack.stack('quit')

--- a/bluesky_gym/envs/static_obstacle_env.py
+++ b/bluesky_gym/envs/static_obstacle_env.py
@@ -92,9 +92,8 @@ class StaticObstacleEnv(gym.Env):
 
         self.pygame_canvas = PygameCanvas(self.window_width, self.window_height)
         self.projection = TopDownProjection(
-            max_distance=MAX_DISTANCE,
-            viewport=(0, 0, self.window_width, self.window_height),
-            ref_lat=0, ref_lon=0,
+            max_distance=MAX_DISTANCE, ref_lat=0, ref_lon=0,
+            window_size=(self.window_width, self.window_height),
         )
 
     def reset(self, seed=None, options=None):

--- a/bluesky_gym/envs/static_obstacle_env.py
+++ b/bluesky_gym/envs/static_obstacle_env.py
@@ -1,6 +1,4 @@
 import numpy as np
-import pygame
-
 import bluesky as bs
 import bluesky_gym.envs.common.functions as fn
 
@@ -8,6 +6,10 @@ import gymnasium as gym
 from gymnasium import spaces
 
 from core.observations import WaypointObservation, ObstacleObservation
+from core.rendering import (
+    PygameCanvas, TopDownProjection,
+    draw_aircraft, draw_waypoint, draw_polygon, RED_ORANGE,
+)
 
 DISTANCE_MARGIN = 5 # km
 
@@ -88,8 +90,12 @@ class StaticObstacleEnv(gym.Env):
 
         self.obstacle_names = []
 
-        self.window = None
-        self.clock = None
+        self.pygame_canvas = PygameCanvas(self.window_width, self.window_height)
+        self.projection = TopDownProjection(
+            max_distance=MAX_DISTANCE,
+            viewport=(0, 0, self.window_width, self.window_height),
+            ref_lat=0, ref_lon=0,
+        )
 
     def reset(self, seed=None, options=None):
         super().reset(seed=seed) 
@@ -103,14 +109,8 @@ class StaticObstacleEnv(gym.Env):
 
         bs.traf.cre(self.agent,actype="A320",acspd=AC_SPD, acalt=ALTITUDE)
 
-        # defining screen coordinates
-        # defining the reference point as the top left corner of the SQUARE screen
-        # from the initial position of the aircraft which is set to be the centre of the screen
         ac_idx = bs.traf.id2idx(self.agent)
-        d = np.sqrt(2*(MAX_DISTANCE/2)**2) #KM
-        lat_ref_point,lon_ref_point = bs.tools.geo.kwikpos(bs.traf.lat[ac_idx], bs.traf.lon[ac_idx], 315, d/NM2KM)
-        
-        self.screen_coords = [lat_ref_point,lon_ref_point]#[52.9, 2.6]
+        self.projection.update_ref(bs.traf.lat[ac_idx], bs.traf.lon[ac_idx])
 
         self._generate_obstacles()
         self._generate_waypoint()
@@ -307,99 +307,27 @@ class StaticObstacleEnv(gym.Env):
         bs.stack.stack(f"SPD {self.agent} {speed_new}")
 
     def _render_frame(self):
-        if self.window is None and self.render_mode == "human":
-            pygame.init()
-            pygame.display.init()
-            self.window = pygame.display.set_mode(self.window_size)
-            
-
-        if self.clock is None and self.render_mode == "human":
-            self.clock = pygame.time.Clock()
-
-        screen_coords = self.screen_coords
-
-        canvas = pygame.Surface(self.window_size)
-        canvas.fill((135,206,235))
-
-        px_per_km = self.window_width/MAX_DISTANCE
-
-        # draw ownship
         ac_idx = bs.traf.id2idx(self.agent)
-        ac_length = 8
-        heading_end_x = ((np.sin(np.deg2rad(bs.traf.hdg[ac_idx])) * ac_length)/MAX_DISTANCE)*self.window_width
-        heading_end_y = ((np.cos(np.deg2rad(bs.traf.hdg[ac_idx])) * ac_length)/MAX_DISTANCE)*self.window_width
+        canvas = self.pygame_canvas.begin_frame()
 
-        qdr, dis = bs.tools.geo.kwikqdrdist(screen_coords[0], screen_coords[1], bs.traf.lat[ac_idx], bs.traf.lon[ac_idx])
-        dis = dis*NM2KM
-        x_actor = ((np.sin(np.deg2rad(qdr))*dis)/MAX_DISTANCE)*self.window_width
-        y_actor = ((-np.cos(np.deg2rad(qdr))*dis)/MAX_DISTANCE)*self.window_width
-        pygame.draw.line(canvas,
-            (235, 52, 52),
-            (x_actor, y_actor),
-            (x_actor+heading_end_x, y_actor-heading_end_y),
-            width = 5
-        )
+        # Draw ownship
+        x, y = self.projection.project(bs.traf.lat[ac_idx], bs.traf.lon[ac_idx])
+        draw_aircraft(canvas, x, y, bs.traf.hdg[ac_idx],
+                      body_km=8, heading_km=50, projection=self.projection,
+                      color=RED_ORANGE, body_width=5)
 
-        # draw heading line
-        heading_length = 50
-        heading_end_x = ((np.sin(np.deg2rad(bs.traf.hdg[ac_idx])) * heading_length)/MAX_DISTANCE)*self.window_width
-        heading_end_y = ((np.cos(np.deg2rad(bs.traf.hdg[ac_idx])) * heading_length)/MAX_DISTANCE)*self.window_width
-
-        pygame.draw.line(canvas,
-            (0,0,0),
-            (x_actor,y_actor),
-            (x_actor+heading_end_x, y_actor-heading_end_y),
-            width = 1
-        )
-
-        # draw obstacles
+        # Draw obstacles
         for vertices in self.obstacle_vertices:
-            points = []
-            for coord in vertices:
-                lat_ref = coord[0]
-                lon_ref = coord[1]
-                qdr, dis = bs.tools.geo.kwikqdrdist(screen_coords[0], screen_coords[1], lat_ref, lon_ref)
-                dis = dis*NM2KM
-                x_ref = (np.sin(np.deg2rad(qdr))*dis)/MAX_DISTANCE*self.window_width
-                y_ref = (-np.cos(np.deg2rad(qdr))*dis)/MAX_DISTANCE*self.window_width
-                points.append((x_ref, y_ref))
-            pygame.draw.polygon(canvas,
-                (0,0,0), points
-            )
+            points = [self.projection.project(v[0], v[1]) for v in vertices]
+            draw_polygon(canvas, points)
 
-        # draw target waypoint
-        indx = 0
-        for lat, lon, reach in zip(self.wpt_lat, self.wpt_lon, self.wpt_reach):
-            
-            indx += 1
-            qdr, dis = bs.tools.geo.kwikqdrdist(screen_coords[0], screen_coords[1], lat, lon)
+        # Draw waypoints
+        for lat, lon, reached in zip(self.wpt_lat, self.wpt_lon, self.wpt_reach):
+            wx, wy = self.projection.project(lat, lon)
+            draw_waypoint(canvas, wx, wy, DISTANCE_MARGIN, self.projection,
+                          reached=bool(reached))
 
-            circle_x = ((np.sin(np.deg2rad(qdr)) * dis * NM2KM)/MAX_DISTANCE)*self.window_width
-            circle_y = (-(np.cos(np.deg2rad(qdr)) * dis * NM2KM)/MAX_DISTANCE)*self.window_width
-
-            color = (255,255,255)
-
-            pygame.draw.circle(
-                canvas, 
-                color,
-                (circle_x,circle_y),
-                radius = 4,
-                width = 0
-            )
-            
-            pygame.draw.circle(
-                canvas, 
-                color,
-                (circle_x,circle_y),
-                radius = (DISTANCE_MARGIN/MAX_DISTANCE)*self.window_width,
-                width = 2
-            )
-
-        self.window.blit(canvas, canvas.get_rect())
-        
-        pygame.display.update()
-        
-        self.clock.tick(self.metadata["render_fps"])
+        self.pygame_canvas.end_frame(canvas)
 
     def close(self):
         bs.stack.stack('quit')

--- a/bluesky_gym/envs/vertical_cr_env.py
+++ b/bluesky_gym/envs/vertical_cr_env.py
@@ -1,6 +1,4 @@
 import numpy as np
-import pygame
-
 import bluesky as bs
 import bluesky_gym.envs.common.functions as fn
 
@@ -10,6 +8,11 @@ from gymnasium import spaces
 from core.observations import (
     OwnAltitudeObservation, TargetAltitudeObservation,
     RunwayDistanceObservation, IntruderObservation,
+)
+from core.rendering import (
+    PygameCanvas, TopDownProjection, SideProfileProjection,
+    draw_aircraft, draw_intruder,
+    draw_side_aircraft, draw_side_intruder, draw_ground, draw_runway, draw_target_altitude,
 )
 
 
@@ -65,8 +68,8 @@ class VerticalCREnv(gym.Env):
 
     def __init__(self, render_mode=None):
         self.window_width = 512
-        self.window_height = 256
-        self.window_size = (self.window_width, self.window_height) # Size of the rendered environment
+        self.window_height = 512
+        self.window_size = (self.window_width, self.window_height)
 
         self.altitude_obs = OwnAltitudeObservation(alt_mean=ALT_MEAN, alt_std=ALT_STD, vz_mean=VZ_MEAN, vz_std=VZ_STD)
         self.target_alt_obs = TargetAltitudeObservation(alt_mean=ALT_MEAN, alt_std=ALT_STD)
@@ -104,15 +107,16 @@ class VerticalCREnv(gym.Env):
         self.total_intrusions = 0
         self.final_altitude = 0
 
-        """
-        If human-rendering is used, `self.window` will be a reference
-        to the window that we draw to. `self.clock` will be a clock that is used
-        to ensure that the environment is rendered at the correct framerate in
-        human-mode. They will remain `None` until human-mode is used for the
-        first time.
-        """
-        self.window = None
-        self.clock = None
+        half_h = self.window_height // 2
+        self.pygame_canvas = PygameCanvas(self.window_width, self.window_height)
+        self.top_projection = TopDownProjection(
+            max_distance=250, ref_lat=0, ref_lon=0,
+            viewport=(0, 0, self.window_width, half_h),
+        )
+        self.side_projection = SideProfileProjection(
+            max_distance=250, max_altitude=5000,
+            viewport=(0, half_h, self.window_width, half_h),
+        )
 
 
     def _get_obs(self):
@@ -233,8 +237,15 @@ class VerticalCREnv(gym.Env):
         alt_init = np.random.randint(ALT_MIN, ALT_MAX)
         self.target_alt = alt_init + np.random.randint(-TARGET_ALT_DIF,TARGET_ALT_DIF)
 
-        bs.traf.cre(self.agent, actype="A320", acalt=alt_init, acspd=AC_SPD)
+        start_lat, start_lon = fn.get_point_at_distance(RWY_LAT, RWY_LON, DEFAULT_RWY_DIS, 270)
+        mid_lat, mid_lon = fn.get_point_at_distance(RWY_LAT, RWY_LON, DEFAULT_RWY_DIS / 2, 270)
+
+        bs.traf.cre(self.agent, actype="A320",
+                    aclat=start_lat, aclon=start_lon, achdg=90,
+                    acalt=alt_init, acspd=AC_SPD)
         bs.traf.swvnav[0] = False
+
+        self.top_projection.update_ref(mid_lat, mid_lon)
 
         self._generate_conflicts()
 
@@ -274,122 +285,58 @@ class VerticalCREnv(gym.Env):
         pass
 
     def _render_frame(self):
-        if self.window is None and self.render_mode == "human":
-            pygame.init()
-            pygame.display.init()
-            self.window = pygame.display.set_mode(self.window_size)
+        ac_idx = bs.traf.id2idx(self.agent)
+        canvas = self.pygame_canvas.begin_frame()
+        ac_length_px = self.side_projection.scale_horizontal(4)
 
-        if self.clock is None and self.render_mode == "human":
-            self.clock = pygame.time.Clock()
-
-        zero_offset = 25
-        max_distance = 180 # width of screen in km
-
-        canvas = pygame.Surface(self.window_size)
-        canvas.fill((135,206,235))
-
-        # draw a ground surface
-        pygame.draw.rect(
-            canvas, 
-            (154,205,50),
-            pygame.Rect(
-                (0,self.window_height-50),
-                (self.window_width, 50)
-                ),
-        )
-        
-        # draw target altitude
-        max_alt = 5000
-        target_alt = int((-1*(self.target_alt-max_alt)/max_alt)*(self.window_height-50))
-
-        pygame.draw.line(
-            canvas,
-            (255,255,255),
-            (0,target_alt),
-            (self.window_width,target_alt)
-        )
-
-        # draw runway
-        runway_length = 30
-        runway_start = int(((self.runway_distance + zero_offset)/max_distance)*self.window_width)
-        runway_end = int(runway_start + (runway_length/max_distance)*self.window_width)
-
-        pygame.draw.line(
-            canvas,
-            (119,136,153),
-            (runway_start,self.window_height - 50),
-            (runway_end,self.window_height - 50),
-            width = 3
-        )
-
-        # draw aircraft
-        aircraft_alt = int((-1*(self.altitude-max_alt)/max_alt)*(self.window_height-50))
-        aircraft_start = int(((zero_offset)/max_distance)*self.window_width)
-        aircraft_end = int(aircraft_start + (4/max_distance)*self.window_width)
-
-        pygame.draw.line(
-            canvas,
-            (0,0,0),
-            (aircraft_start,aircraft_alt),
-            (aircraft_end,aircraft_alt),
-            width = 5
-        )
+        # --- Top half: top-down view ---
+        self.top_projection.clip(canvas)
+        ax, ay = self.top_projection.project(bs.traf.lat[ac_idx], bs.traf.lon[ac_idx])
+        draw_aircraft(canvas, ax, ay, bs.traf.hdg[ac_idx],
+                      body_km=8, heading_km=50, projection=self.top_projection)
 
         for i in range(NUM_INTRUDERS):
-            int_idx = i+1
-            int_alt = int((-1*(bs.traf.alt[int_idx]-max_alt)/max_alt)*(self.window_height-50))
-            int_x_dis = self.intruder_distance[int_idx - 1] * self.cos_bearing[int_idx - 1]
-            int_y_dis = self.intruder_distance[int_idx - 1] * self.sin_bearing[int_idx - 1]
-            width_temp = int(5+int_y_dis/20)
-            aircraft_start = int(((zero_offset + int_x_dis )/max_distance)*self.window_width)
-            aircraft_end = int(aircraft_start + (4/max_distance)*self.window_width)
-            color = (255,255,255) if abs(int_y_dis) > DISTANCE_MARGIN else 'red'
+            int_idx = i + 1
+            ix, iy = self.top_projection.project(bs.traf.lat[int_idx], bs.traf.lon[int_idx])
+            int_dis = bs.tools.geo.kwikdist(
+                bs.traf.lat[ac_idx], bs.traf.lon[ac_idx],
+                bs.traf.lat[int_idx], bs.traf.lon[int_idx])
+            vert_dis = abs(bs.traf.alt[ac_idx] - bs.traf.alt[int_idx])
+            draw_intruder(canvas, ix, iy, bs.traf.hdg[int_idx], self.top_projection,
+                          body_km=3, heading_km=10,
+                          safety_radius_km=INTRUSION_DISTANCE * NM2KM,
+                          in_intrusion=int_dis < INTRUSION_DISTANCE and vert_dis < VERTICAL_MARGIN)
+        self.top_projection.unclip(canvas)
 
-            pygame.draw.line(
-                canvas,
-                color,
-                (aircraft_start,int_alt),
-                (aircraft_end,int_alt),
-                width = width_temp
-            )
+        # --- Bottom half: side profile (x-aligned with top view) ---
+        self.side_projection.clip(canvas)
+        draw_ground(canvas, self.side_projection)
 
-            hor_margin = (DISTANCE_MARGIN*NM2KM/max_distance)*self.window_width
-            ver_margin = (VERTICAL_MARGIN/max_alt)*self.window_height
+        _, target_y = self.side_projection.project(0, self.target_alt)
+        draw_target_altitude(canvas, target_y, self.side_projection)
 
-            pygame.draw.line(
-                canvas,
-                'black',
-                (aircraft_start-hor_margin/2,int_alt-ver_margin),
-                (aircraft_end+hor_margin/2,int_alt-ver_margin),
-                width = 1
-            )
-            pygame.draw.line(
-                canvas,
-                'black',
-                (aircraft_start-hor_margin/2,int_alt+ver_margin),
-                (aircraft_end+hor_margin/2,int_alt+ver_margin),
-                width = 1
-            )
-            pygame.draw.line(
-                canvas,
-                'black',
-                (aircraft_start-hor_margin/2,int_alt-ver_margin),
-                (aircraft_start-hor_margin/2,int_alt+ver_margin),
-                width = 1
-            )
-            pygame.draw.line(
-                canvas,
-                'black',
-                (aircraft_end+hor_margin/2,int_alt-ver_margin),
-                (aircraft_end+hor_margin/2,int_alt+ver_margin),
-                width = 1
-            )
+        rwy_x, _ = self.top_projection.project(RWY_LAT, RWY_LON)
+        _, rwy_y = self.side_projection.project(0, 0)
+        draw_runway(canvas, rwy_x, rwy_y, self.side_projection.scale_horizontal(30))
 
+        ac_side_y = self.side_projection.altitude_to_y(self.altitude)
+        draw_side_aircraft(canvas, ax, ac_side_y, ac_length_px)
 
+        for i in range(NUM_INTRUDERS):
+            int_idx = i + 1
+            ix, _ = self.top_projection.project(bs.traf.lat[int_idx], bs.traf.lon[int_idx])
+            int_side_y = self.side_projection.altitude_to_y(bs.traf.alt[int_idx])
+            int_dis = bs.tools.geo.kwikdist(
+                bs.traf.lat[ac_idx], bs.traf.lon[ac_idx],
+                bs.traf.lat[int_idx], bs.traf.lon[int_idx])
+            vert_dis = abs(bs.traf.alt[ac_idx] - bs.traf.alt[int_idx])
+            draw_side_intruder(canvas, ix, int_side_y, ac_length_px, self.side_projection,
+                               in_intrusion=int_dis < INTRUSION_DISTANCE and vert_dis < VERTICAL_MARGIN,
+                               hor_margin_km=INTRUSION_DISTANCE * NM2KM,
+                               ver_margin_alt=VERTICAL_MARGIN)
+        self.side_projection.unclip(canvas)
 
-        self.window.blit(canvas, canvas.get_rect())
-        pygame.display.update()
-        self.clock.tick(self.metadata["render_fps"])
+        self.pygame_canvas.end_frame(canvas)
         
     def close(self):
         bs.stack.stack('quit')

--- a/core/rendering.py
+++ b/core/rendering.py
@@ -1,0 +1,320 @@
+"""
+Rendering utilities for BlueSky Gym environments.
+
+Provides reusable canvas management, coordinate projections, and drawing
+functions for top-down and side-profile views. No BlueSky dependency —
+environments pass world coordinates, this module handles screen output.
+"""
+
+import numpy as np
+import pygame
+
+NM2KM = 1.852
+DEG2KM = 111.32
+
+# ---------------------------------------------------------------------------
+# Colors
+# ---------------------------------------------------------------------------
+SKY_BLUE = (135, 206, 235)
+BLACK = (0, 0, 0)
+WHITE = (255, 255, 255)
+GRAY = (80, 80, 80)
+LIGHT_GRAY = (155, 155, 155)
+CRIMSON = (220, 20, 60)
+OLIVE_GREEN = (154, 205, 50)
+SLATE_GRAY = (119, 136, 153)
+BRIGHT_GREEN = (3, 252, 11)
+RED_ORANGE = (235, 52, 52)
+
+
+# ---------------------------------------------------------------------------
+# Canvas
+# ---------------------------------------------------------------------------
+class PygameCanvas:
+    """Manages a pygame window and per-frame surface lifecycle."""
+
+    def __init__(self, width, height, render_fps=120, bg_color=SKY_BLUE):
+        self.width = width
+        self.height = height
+        self.window_size = (width, height)
+        self.render_fps = render_fps
+        self.bg_color = bg_color
+        self.window = None
+        self.clock = None
+
+    def begin_frame(self):
+        if self.window is None:
+            pygame.init()
+            pygame.display.init()
+            self.window = pygame.display.set_mode(self.window_size)
+        if self.clock is None:
+            self.clock = pygame.time.Clock()
+        canvas = pygame.Surface(self.window_size)
+        canvas.fill(self.bg_color)
+        return canvas
+
+    def end_frame(self, canvas):
+        self.window.blit(canvas, canvas.get_rect())
+        pygame.event.pump()
+        pygame.display.update()
+        self.clock.tick(self.render_fps)
+
+
+# ---------------------------------------------------------------------------
+# Projections
+# ---------------------------------------------------------------------------
+class TopDownProjection:
+    """North-up flat-earth projection from lat/lon to screen pixels.
+
+    Uses a flat-earth approximation to convert geographic coordinates to
+    screen positions relative to a reference point. This is a simplification
+    that assumes a locally flat surface — it does not account for Earth
+    curvature and breaks down near the poles or for large airspaces
+    (> ~500 km). For the typical scenario sizes in BlueSky Gym this is
+    accurate to within ~0.3%.
+
+    Convention: North is up, East is right.
+
+    Parameters
+    ----------
+    max_distance : float
+        World width in km that maps to the viewport width.
+    viewport : tuple of (x_off, y_off, width, height)
+        Region of the canvas this projection draws into.
+    ref_lat : float
+        Reference latitude (center of view) in degrees.
+    ref_lon : float
+        Reference longitude (center of view) in degrees.
+    """
+
+    def __init__(self, max_distance, viewport, ref_lat, ref_lon):
+        self.max_distance = max_distance
+        self.viewport = viewport
+        self.ref_lat = ref_lat
+        self.ref_lon = ref_lon
+        self._cos_ref_lat = np.cos(np.deg2rad(ref_lat))
+
+        x_off, y_off, w, h = viewport
+        self._origin = (x_off + w / 2, y_off + h / 2)
+        self._px_per_km = w / max_distance
+
+    @property
+    def center(self):
+        return self._origin
+
+    @property
+    def px_per_km(self):
+        return self._px_per_km
+
+    def update_ref(self, ref_lat, ref_lon):
+        """Update the reference point (e.g. to follow the ownship)."""
+        self.ref_lat = ref_lat
+        self.ref_lon = ref_lon
+        self._cos_ref_lat = np.cos(np.deg2rad(ref_lat))
+
+    def project(self, lat, lon):
+        """Convert lat/lon to canvas (x, y)."""
+        dx_km = (lon - self.ref_lon) * self._cos_ref_lat * DEG2KM
+        dy_km = (lat - self.ref_lat) * DEG2KM
+        return (self._origin[0] + dx_km * self._px_per_km,
+                self._origin[1] - dy_km * self._px_per_km)
+
+    def direction(self, heading_deg, length_km):
+        """Convert a heading and length to a screen delta (dx, dy).
+
+        Heading follows aviation convention: 0° = North, 90° = East, clockwise.
+        """
+        heading_rad = np.deg2rad(heading_deg)
+        px = length_km * self._px_per_km
+        return np.sin(heading_rad) * px, -np.cos(heading_rad) * px
+
+    def scale(self, km):
+        """Convert a world distance in km to pixels."""
+        return km * self._px_per_km
+
+
+class SideProfileProjection:
+    """Side-profile projection: horizontal distance + altitude to screen pixels.
+
+    Parameters
+    ----------
+    max_distance : float
+        World width in km mapped to viewport width.
+    max_altitude : float
+        Maximum altitude value mapped to the top of the drawable area.
+    viewport : tuple of (x_off, y_off, width, height)
+        Region of the canvas this projection draws into.
+    x_offset : float
+        Horizontal pixel offset for the origin (ownship position).
+    ground_height : int
+        Height in pixels of the ground strip at the bottom of the viewport.
+    """
+
+    def __init__(self, max_distance, max_altitude, viewport,
+                 x_offset=25, ground_height=50):
+        self.max_distance = max_distance
+        self.max_altitude = max_altitude
+        self.viewport = viewport
+        self.x_offset = x_offset
+        self.ground_height = ground_height
+        self._x_off, self._y_off, self._w, self._h = viewport
+
+    def project(self, distance_km, altitude):
+        """Convert distance/altitude to canvas (x, y)."""
+        x = ((distance_km + self.x_offset) / self.max_distance) * self._w + self._x_off
+        y = (1.0 - altitude / self.max_altitude) * (self._h - self.ground_height) + self._y_off
+        return x, y
+
+    def altitude_to_y(self, altitude):
+        """Convert altitude to canvas y-coordinate (for split-level use)."""
+        return (1.0 - altitude / self.max_altitude) * (self._h - self.ground_height) + self._y_off
+
+    def scale_horizontal(self, km):
+        """Convert horizontal distance in km to pixels."""
+        return (km / self.max_distance) * self._w
+
+    def scale_vertical(self, altitude_units):
+        """Convert altitude units to pixels."""
+        return (altitude_units / self.max_altitude) * (self._h - self.ground_height)
+
+
+# ---------------------------------------------------------------------------
+# Top-down drawing functions
+# ---------------------------------------------------------------------------
+def draw_aircraft(canvas, x, y, heading_deg, body_km, heading_km, projection,
+                  *, color=BLACK, body_width=4, heading_width=1,
+                  heading_color=None):
+    """Draw an aircraft: body line centered on (x, y) with a heading indicator."""
+    if heading_color is None:
+        heading_color = color
+
+    bdx, bdy = projection.direction(heading_deg, body_km)
+    pygame.draw.line(canvas, color,
+                     (x - bdx / 2, y - bdy / 2),
+                     (x + bdx / 2, y + bdy / 2),
+                     width=body_width)
+
+    hdx, hdy = projection.direction(heading_deg, heading_km)
+    pygame.draw.line(canvas, heading_color,
+                     (x, y), (x + hdx, y + hdy),
+                     width=heading_width)
+
+
+def draw_intruder(canvas, x, y, heading_deg, projection, *,
+                  body_km=3, heading_km=10, safety_radius_km=None,
+                  in_intrusion=False,
+                  color_safe=GRAY, color_intrusion=CRIMSON):
+    """Draw an intruder aircraft with optional safety circle."""
+    color = color_intrusion if in_intrusion else color_safe
+
+    draw_aircraft(canvas, x, y, heading_deg,
+                  body_km=body_km, heading_km=heading_km,
+                  projection=projection, color=color)
+
+    if safety_radius_km is not None:
+        radius_px = projection.scale(safety_radius_km)
+        pygame.draw.circle(canvas, color, (int(x), int(y)),
+                           radius=int(radius_px), width=2)
+
+
+def draw_waypoint(canvas, x, y, margin_km, projection, *,
+                  reached=False,
+                  color_active=WHITE, color_reached=LIGHT_GRAY):
+    """Draw a waypoint marker: filled dot + margin ring."""
+    color = color_reached if reached else color_active
+    pygame.draw.circle(canvas, color, (int(x), int(y)),
+                       radius=4, width=0)
+    margin_px = projection.scale(margin_km)
+    pygame.draw.circle(canvas, color, (int(x), int(y)),
+                       radius=int(margin_px), width=2)
+
+
+def draw_polygon(canvas, points, *, color=BLACK, filled=True, width=0):
+    """Draw a polygon shape (airspace boundary, obstacle, etc.)."""
+    if filled:
+        pygame.draw.polygon(canvas, color, points)
+    else:
+        pygame.draw.polygon(canvas, color, points, width=max(width, 1))
+
+
+def draw_radial_line(canvas, x, y, heading_deg, length_km, projection, *,
+                     color=BLACK, width=1):
+    """Draw a line from (x, y) in a given heading direction."""
+    dx, dy = projection.direction(heading_deg, length_km)
+    pygame.draw.line(canvas, color,
+                     (x, y), (x + dx, y + dy),
+                     width=width)
+
+
+# ---------------------------------------------------------------------------
+# Side-profile drawing functions
+# ---------------------------------------------------------------------------
+def draw_side_aircraft(canvas, x, y, length_px, *, color=BLACK, width=5):
+    """Draw an aircraft as a horizontal line in side-profile view."""
+    pygame.draw.line(canvas, color,
+                     (int(x), int(y)),
+                     (int(x + length_px), int(y)),
+                     width=width)
+
+
+def draw_side_intruder(canvas, x, y, length_px, projection, *,
+                       lateral_distance=0, in_intrusion=False,
+                       color_safe=WHITE, color_intrusion=(255, 0, 0),
+                       hor_margin_km=None, ver_margin_alt=None):
+    """Draw a side-profile intruder with depth-based width and collision box.
+
+    Parameters
+    ----------
+    lateral_distance : float
+        Cross-track distance, used to vary line width for depth effect.
+    hor_margin_km : float, optional
+        Horizontal half-width of collision box in km.
+    ver_margin_alt : float, optional
+        Vertical half-height of collision box in altitude units.
+    """
+    color = color_intrusion if in_intrusion else color_safe
+    line_width = max(1, int(5 + lateral_distance / 20))
+
+    draw_side_aircraft(canvas, x, y, length_px, color=color, width=line_width)
+
+    if hor_margin_km is not None and ver_margin_alt is not None:
+        hw = projection.scale_horizontal(hor_margin_km) / 2
+        hh = projection.scale_vertical(ver_margin_alt)
+        draw_collision_box(canvas, x + length_px / 2, y, hw, hh)
+
+
+def draw_collision_box(canvas, cx, cy, half_width_px, half_height_px, *,
+                       color=BLACK, width=1):
+    """Draw a rectangle outline centered on (cx, cy)."""
+    left = cx - half_width_px
+    right = cx + half_width_px
+    top = cy - half_height_px
+    bottom = cy + half_height_px
+    pygame.draw.line(canvas, color, (left, top), (right, top), width=width)
+    pygame.draw.line(canvas, color, (left, bottom), (right, bottom), width=width)
+    pygame.draw.line(canvas, color, (left, top), (left, bottom), width=width)
+    pygame.draw.line(canvas, color, (right, top), (right, bottom), width=width)
+
+
+def draw_ground(canvas, viewport, *, ground_height=50, color=OLIVE_GREEN):
+    """Draw a ground rectangle at the bottom of a viewport."""
+    x_off, y_off, w, h = viewport
+    pygame.draw.rect(canvas, color,
+                     pygame.Rect((x_off, y_off + h - ground_height),
+                                 (w, ground_height)))
+
+
+def draw_runway(canvas, x_start, y, length_px, *, color=SLATE_GRAY, width=3):
+    """Draw a runway line on the ground surface."""
+    pygame.draw.line(canvas, color,
+                     (int(x_start), int(y)),
+                     (int(x_start + length_px), int(y)),
+                     width=width)
+
+
+def draw_target_altitude(canvas, y, viewport, *, color=WHITE):
+    """Draw a horizontal target altitude line spanning the viewport width."""
+    x_off, _, w, _ = viewport
+    pygame.draw.line(canvas, color,
+                     (x_off, int(y)),
+                     (x_off + w, int(y)))

--- a/core/rendering.py
+++ b/core/rendering.py
@@ -79,15 +79,20 @@ class TopDownProjection:
     ----------
     max_distance : float
         World width in km that maps to the viewport width.
-    viewport : tuple of (x_off, y_off, width, height)
-        Region of the canvas this projection draws into.
     ref_lat : float
         Reference latitude (center of view) in degrees.
     ref_lon : float
         Reference longitude (center of view) in degrees.
+    window_size : tuple of (width, height), optional
+        Canvas size in pixels. Uses the full canvas as the drawing area.
+        Provide this OR viewport, not both.
+    viewport : tuple of (x_off, y_off, width, height), optional
+        Sub-region of the canvas for split-level views. Overrides window_size.
     """
 
-    def __init__(self, max_distance, viewport, ref_lat, ref_lon):
+    def __init__(self, max_distance, ref_lat, ref_lon, window_size=None, viewport=None):
+        if viewport is None:
+            viewport = (0, 0, *window_size)
         self.max_distance = max_distance
         self.viewport = viewport
         self.ref_lat = ref_lat
@@ -132,6 +137,15 @@ class TopDownProjection:
         """Convert a world distance in km to pixels."""
         return km * self._px_per_km
 
+    def clip(self, canvas):
+        """Restrict drawing to this projection's viewport. Call unclip() when done."""
+        canvas.set_clip(pygame.Rect(self.viewport))
+
+    def unclip(self, canvas):
+        """Remove viewport clipping and draw a border around the viewport."""
+        canvas.set_clip(None)
+        pygame.draw.rect(canvas, WHITE, pygame.Rect(self.viewport), width=1)
+
 
 class SideProfileProjection:
     """Side-profile projection: horizontal distance + altitude to screen pixels.
@@ -142,16 +156,22 @@ class SideProfileProjection:
         World width in km mapped to viewport width.
     max_altitude : float
         Maximum altitude value mapped to the top of the drawable area.
-    viewport : tuple of (x_off, y_off, width, height)
-        Region of the canvas this projection draws into.
+    window_size : tuple of (width, height), optional
+        Canvas size in pixels. Uses the full canvas as the drawing area.
+        Provide this OR viewport, not both.
+    viewport : tuple of (x_off, y_off, width, height), optional
+        Sub-region of the canvas for split-level views. Overrides window_size.
     x_offset : float
         Horizontal pixel offset for the origin (ownship position).
     ground_height : int
         Height in pixels of the ground strip at the bottom of the viewport.
     """
 
-    def __init__(self, max_distance, max_altitude, viewport,
+    def __init__(self, max_distance, max_altitude,
+                 window_size=None, viewport=None,
                  x_offset=25, ground_height=50):
+        if viewport is None:
+            viewport = (0, 0, *window_size)
         self.max_distance = max_distance
         self.max_altitude = max_altitude
         self.viewport = viewport
@@ -176,6 +196,15 @@ class SideProfileProjection:
     def scale_vertical(self, altitude_units):
         """Convert altitude units to pixels."""
         return (altitude_units / self.max_altitude) * (self._h - self.ground_height)
+
+    def clip(self, canvas):
+        """Restrict drawing to this projection's viewport. Call unclip() when done."""
+        canvas.set_clip(pygame.Rect(self.viewport))
+
+    def unclip(self, canvas):
+        """Remove viewport clipping and draw a border around the viewport."""
+        canvas.set_clip(None)
+        pygame.draw.rect(canvas, WHITE, pygame.Rect(self.viewport), width=1)
 
 
 # ---------------------------------------------------------------------------
@@ -246,6 +275,13 @@ def draw_radial_line(canvas, x, y, heading_deg, length_km, projection, *,
                      width=width)
 
 
+def draw_line(canvas, x1, y1, x2, y2, *, color=BLACK, width=1):
+    """Draw a line between two screen positions."""
+    pygame.draw.line(canvas, color,
+                     (int(x1), int(y1)), (int(x2), int(y2)),
+                     width=width)
+
+
 # ---------------------------------------------------------------------------
 # Side-profile drawing functions
 # ---------------------------------------------------------------------------
@@ -258,29 +294,26 @@ def draw_side_aircraft(canvas, x, y, length_px, *, color=BLACK, width=5):
 
 
 def draw_side_intruder(canvas, x, y, length_px, projection, *,
-                       lateral_distance=0, in_intrusion=False,
-                       color_safe=WHITE, color_intrusion=(255, 0, 0),
+                       color=BLACK, width=5, in_intrusion=False,
                        hor_margin_km=None, ver_margin_alt=None):
-    """Draw a side-profile intruder with depth-based width and collision box.
+    """Draw a side-profile intruder aircraft with optional collision box.
 
     Parameters
     ----------
-    lateral_distance : float
-        Cross-track distance, used to vary line width for depth effect.
+    in_intrusion : bool
+        If True, the collision box is drawn in red.
     hor_margin_km : float, optional
-        Horizontal half-width of collision box in km.
+        Half-width of collision box in km (matches safety_radius_km in top view).
     ver_margin_alt : float, optional
-        Vertical half-height of collision box in altitude units.
+        Half-height of collision box in altitude units.
     """
-    color = color_intrusion if in_intrusion else color_safe
-    line_width = max(1, int(5 + lateral_distance / 20))
-
-    draw_side_aircraft(canvas, x, y, length_px, color=color, width=line_width)
+    draw_side_aircraft(canvas, x, y, length_px, color=color, width=width)
 
     if hor_margin_km is not None and ver_margin_alt is not None:
-        hw = projection.scale_horizontal(hor_margin_km) / 2
+        hw = projection.scale_horizontal(hor_margin_km)
         hh = projection.scale_vertical(ver_margin_alt)
-        draw_collision_box(canvas, x + length_px / 2, y, hw, hh)
+        box_color = CRIMSON if in_intrusion else BLACK
+        draw_collision_box(canvas, x + length_px / 2, y, hw, hh, color=box_color)
 
 
 def draw_collision_box(canvas, cx, cy, half_width_px, half_height_px, *,
@@ -296,12 +329,12 @@ def draw_collision_box(canvas, cx, cy, half_width_px, half_height_px, *,
     pygame.draw.line(canvas, color, (right, top), (right, bottom), width=width)
 
 
-def draw_ground(canvas, viewport, *, ground_height=50, color=OLIVE_GREEN):
-    """Draw a ground rectangle at the bottom of a viewport."""
-    x_off, y_off, w, h = viewport
+def draw_ground(canvas, projection, *, color=OLIVE_GREEN):
+    """Draw a ground rectangle at the bottom of the projection's viewport."""
+    x_off, y_off, w, h = projection.viewport
     pygame.draw.rect(canvas, color,
-                     pygame.Rect((x_off, y_off + h - ground_height),
-                                 (w, ground_height)))
+                     pygame.Rect((x_off, y_off + h - projection.ground_height),
+                                 (w, projection.ground_height)))
 
 
 def draw_runway(canvas, x_start, y, length_px, *, color=SLATE_GRAY, width=3):
@@ -312,9 +345,9 @@ def draw_runway(canvas, x_start, y, length_px, *, color=SLATE_GRAY, width=3):
                      width=width)
 
 
-def draw_target_altitude(canvas, y, viewport, *, color=WHITE):
-    """Draw a horizontal target altitude line spanning the viewport width."""
-    x_off, _, w, _ = viewport
+def draw_target_altitude(canvas, y, projection, *, color=WHITE):
+    """Draw a horizontal target altitude line spanning the projection's viewport width."""
+    x_off, _, w, _ = projection.viewport
     pygame.draw.line(canvas, color,
                      (x_off, int(y)),
                      (x_off + w, int(y)))


### PR DESCRIPTION
This PR reduces code duplication in the rendering of the different environments, increasing consistency. Building the rendering through the standardized rendering methods is still handled at environment level. 

It could be considered to completely move rendering away from the environment based on the instantiated objects, but this might come at the cost of 'hackability' for people reading through the environment. 

Additionally, it is now possible to combine two rendering views in your environment in the case the environment contains both vertical, and lateral components. To illustrate this, VerticalCREnv-v0 now uses this split view by default. 

Other things addressed in this PR:

- Issue #41, which related to inconsistent heading usage in simulator logic and rendering logic. All rendering is now done with North up and East to the right instead of Cartesian which was used for some of the environments. 
- Issue #2 

